### PR TITLE
Making PBS_MOM to work with multi-servers (PR 3)

### DIFF
--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -567,7 +567,7 @@ enum resv_states { RESV_NONE, RESV_UNCONFIRMED, RESV_CONFIRMED, RESV_WAIT,
 	RESV_BEING_DELETED, RESV_DELETED, RESV_DELETING_JOBS, RESV_DEGRADED,
 	RESV_BEING_ALTERED, RESV_IN_CONFLICT };
 
-enum pbs_obj_type {OTHERS = -1, JOB, RESERVATION, NODE};  /* For the purpose of sharding logic */
+enum pbs_obj_type {OTHERS = -1, JOB, RESERVATION, NODE};
 
 #ifdef _USRDLL		/* This is only for building Windows DLLs
 			 * and not their static libraries

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -567,7 +567,7 @@ enum resv_states { RESV_NONE, RESV_UNCONFIRMED, RESV_CONFIRMED, RESV_WAIT,
 	RESV_BEING_DELETED, RESV_DELETED, RESV_DELETING_JOBS, RESV_DEGRADED,
 	RESV_BEING_ALTERED, RESV_IN_CONFLICT };
 
-enum pbs_obj_type {JOB, RESERVATION, NODE};  /* For the purpose of sharding logic */
+enum pbs_obj_type {SHARD_UNKNOWN = -1, SHARD_JOB, SHARD_RESERVATION, SHARD_NODE};  /* For the purpose of sharding logic */
 
 #ifdef _USRDLL		/* This is only for building Windows DLLs
 			 * and not their static libraries

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -567,7 +567,7 @@ enum resv_states { RESV_NONE, RESV_UNCONFIRMED, RESV_CONFIRMED, RESV_WAIT,
 	RESV_BEING_DELETED, RESV_DELETED, RESV_DELETING_JOBS, RESV_DEGRADED,
 	RESV_BEING_ALTERED, RESV_IN_CONFLICT };
 
-enum pbs_obj_type {SHARD_UNKNOWN = -1, SHARD_JOB, SHARD_RESERVATION, SHARD_NODE};  /* For the purpose of sharding logic */
+enum pbs_obj_type {OTHERS = -1, JOB, RESERVATION, NODE};  /* For the purpose of sharding logic */
 
 #ifdef _USRDLL		/* This is only for building Windows DLLs
 			 * and not their static libraries

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -811,7 +811,6 @@ extern char *(*pfn_pbs_submit_resv)(int, struct attropl *, char *);
 extern int (*pfn_pbs_delresv)(int, char *, char *);
 extern int (*pfn_pbs_terminate)(int, int, char *);
 extern preempt_job_info *(*pfn_pbs_preempt_jobs)(int, char**);
-
 #ifdef	__cplusplus
 }
 #endif

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -535,10 +535,11 @@ extern int usepool(int, int);
 
 extern enum vnode_sharing place_sharing_type(char *, enum vnode_sharing);
 
-extern int get_svr_shard_connection(int, enum pbs_obj_type, void *);
+extern int get_svr_shard_connection(int, enum pbs_obj_type, void *, int *);
 extern void set_new_shard_context(int);
 extern int tcp_connect(int, char *, int, char *);
 extern int initialise_shard_conn(int);
+extern int (*pfn_connect)(int, char *, int , char *);
 
 /* This was added to pbs_ifl.h for use by AIF */
 extern int 	pbs_isexecutable(char *);

--- a/src/lib/Libifl/int_hook.c
+++ b/src/lib/Libifl/int_hook.c
@@ -78,7 +78,7 @@ PBSD_hookbuf(int c, int reqtype, int seq, char *buf, int len, char *hook_filenam
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL, &index);
+		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}
@@ -201,7 +201,7 @@ PBSD_delhookfile(int c, char *hook_filename, int prot, char **msgid)
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL, &index);
+		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}

--- a/src/lib/Libifl/int_hook.c
+++ b/src/lib/Libifl/int_hook.c
@@ -75,9 +75,10 @@ PBSD_hookbuf(int c, int reqtype, int seq, char *buf, int len, char *hook_filenam
 	struct batch_reply   *reply;
 	int	rc;
 	int	sock;
+	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL);
+		sock = get_svr_shard_connection(c, -1, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}
@@ -197,9 +198,10 @@ PBSD_delhookfile(int c, char *hook_filename, int prot, char **msgid)
 	struct batch_reply   *reply;
 	int	rc;
 	int	sock;
+	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL);
+		sock = get_svr_shard_connection(c, -1, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}

--- a/src/lib/Libifl/int_hook.c
+++ b/src/lib/Libifl/int_hook.c
@@ -78,7 +78,7 @@ PBSD_hookbuf(int c, int reqtype, int seq, char *buf, int len, char *hook_filenam
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+		sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}
@@ -201,7 +201,7 @@ PBSD_delhookfile(int c, char *hook_filename, int prot, char **msgid)
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+		sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}

--- a/src/lib/Libifl/int_jcred.c
+++ b/src/lib/Libifl/int_jcred.c
@@ -81,7 +81,7 @@ PBSD_jcred(int c, int type, char *buf, int len, int prot, char **msgid)
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+		sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}

--- a/src/lib/Libifl/int_jcred.c
+++ b/src/lib/Libifl/int_jcred.c
@@ -81,7 +81,7 @@ PBSD_jcred(int c, int type, char *buf, int len, int prot, char **msgid)
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL, &index);
+		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}

--- a/src/lib/Libifl/int_jcred.c
+++ b/src/lib/Libifl/int_jcred.c
@@ -78,9 +78,10 @@ PBSD_jcred(int c, int type, char *buf, int len, int prot, char **msgid)
 	int			rc;
 	struct batch_reply	*reply = NULL;
 	int	sock;
+	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL);
+		sock = get_svr_shard_connection(c, -1, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}

--- a/src/lib/Libifl/int_manage2.c
+++ b/src/lib/Libifl/int_manage2.c
@@ -80,14 +80,14 @@ PBSD_mgr_put(int c, int function, int command, int objtype, char *objname, struc
 	int index;
 
 	if (prot == PROT_TCP) {
-		int shardtype = SHARD_UNKNOWN;
+		int shardtype = OTHERS;
 		char *shardhint = NULL;
 		if (objtype == MGR_OBJ_JOB) {
-			shardtype = SHARD_JOB;
+			shardtype = JOB;
 			shardhint = objname;
 		}
 		else if (objtype == MGR_OBJ_RESV) {
-			shardtype = SHARD_RESERVATION;
+			shardtype = RESERVATION;
 			shardhint = objname;
 		}
 

--- a/src/lib/Libifl/int_manage2.c
+++ b/src/lib/Libifl/int_manage2.c
@@ -80,11 +80,18 @@ PBSD_mgr_put(int c, int function, int command, int objtype, char *objname, struc
 	int index;
 
 	if (prot == PROT_TCP) {
+		int shardtype = SHARD_UNKNOWN;
 		char *shardhint = NULL;
-		if (objtype == MGR_OBJ_JOB || objtype == MGR_OBJ_RESV)
+		if (objtype == MGR_OBJ_JOB) {
+			shardtype = SHARD_JOB;
 			shardhint = objname;
+		}
+		else if (objtype == MGR_OBJ_RESV) {
+			shardtype = SHARD_RESERVATION;
+			shardhint = objname;
+		}
 
-		sock = get_svr_shard_connection(c, JOB, shardhint, &index);
+		sock = get_svr_shard_connection(c, shardtype, shardhint, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_manage2.c
+++ b/src/lib/Libifl/int_manage2.c
@@ -77,13 +77,14 @@ PBSD_mgr_put(int c, int function, int command, int objtype, char *objname, struc
 {
 	int rc;
 	int sock;
+	int index;
 
 	if (prot == PROT_TCP) {
 		char *shardhint = NULL;
 		if (objtype == MGR_OBJ_JOB || objtype == MGR_OBJ_RESV)
 			shardhint = objname;
 
-		sock = get_svr_shard_connection(c, JOB, shardhint);
+		sock = get_svr_shard_connection(c, JOB, shardhint, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_msg2.c
+++ b/src/lib/Libifl/int_msg2.c
@@ -75,7 +75,7 @@ PBSD_msg_put(int c, char *jobid, int fileopt, char *msg, char *extend, int prot,
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+		sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);
@@ -125,7 +125,7 @@ PBSD_py_spawn_put(int c, char *jobid, char **argv, char **envp, int prot, char *
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+		sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);
@@ -165,7 +165,7 @@ PBSD_relnodes_put(int c, char *jobid, char *node_list, char *extend, int prot, c
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+		sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_msg2.c
+++ b/src/lib/Libifl/int_msg2.c
@@ -72,9 +72,10 @@ PBSD_msg_put(int c, char *jobid, int fileopt, char *msg, char *extend, int prot,
 {
 	int rc = 0;
 	int sock;
+	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL);
+		sock = get_svr_shard_connection(c, -1, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);
@@ -121,9 +122,10 @@ PBSD_py_spawn_put(int c, char *jobid, char **argv, char **envp, int prot, char *
 {
 	int rc = 0;
 	int sock;
+	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL);
+		sock = get_svr_shard_connection(c, -1, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);
@@ -160,9 +162,10 @@ PBSD_relnodes_put(int c, char *jobid, char *node_list, char *extend, int prot, c
 {
 	int rc = 0;
 	int sock;
+	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL);
+		sock = get_svr_shard_connection(c, -1, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_msg2.c
+++ b/src/lib/Libifl/int_msg2.c
@@ -75,7 +75,7 @@ PBSD_msg_put(int c, char *jobid, int fileopt, char *msg, char *extend, int prot,
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL, &index);
+		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);
@@ -125,7 +125,7 @@ PBSD_py_spawn_put(int c, char *jobid, char **argv, char **envp, int prot, char *
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL, &index);
+		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);
@@ -165,7 +165,7 @@ PBSD_relnodes_put(int c, char *jobid, char *node_list, char *extend, int prot, c
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL, &index);
+		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_rdrpy.c
+++ b/src/lib/Libifl/int_rdrpy.c
@@ -123,7 +123,7 @@ PBSD_rdrpy(int c)
 		return NULL;
 	}
 
-	sock = get_svr_shard_connection(c, -1, NULL, &index);
+	sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 	if (sock == -1) {
 		pbs_errno = PBSE_NOCONNECTION;
 		return NULL;

--- a/src/lib/Libifl/int_rdrpy.c
+++ b/src/lib/Libifl/int_rdrpy.c
@@ -123,7 +123,7 @@ PBSD_rdrpy(int c)
 		return NULL;
 	}
 
-	sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+	sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 	if (sock == -1) {
 		pbs_errno = PBSE_NOCONNECTION;
 		return NULL;

--- a/src/lib/Libifl/int_rdrpy.c
+++ b/src/lib/Libifl/int_rdrpy.c
@@ -114,6 +114,7 @@ PBSD_rdrpy(int c)
 	int rc;
 	struct batch_reply *reply;
 	int sock;
+	int index;
 
 	/* clear any prior error message */
 
@@ -122,7 +123,7 @@ PBSD_rdrpy(int c)
 		return NULL;
 	}
 
-	sock = get_svr_shard_connection(c, -1, NULL);
+	sock = get_svr_shard_connection(c, -1, NULL, &index);
 	if (sock == -1) {
 		pbs_errno = PBSE_NOCONNECTION;
 		return NULL;

--- a/src/lib/Libifl/int_sig2.c
+++ b/src/lib/Libifl/int_sig2.c
@@ -72,9 +72,10 @@ PBSD_sig_put(int c, char *jobid, char *signal, char *extend, int prot, char **ms
 {
 	int rc = 0;
 	int sock;
+	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, JOB, jobid);
+		sock = get_svr_shard_connection(c, JOB, jobid, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_sig2.c
+++ b/src/lib/Libifl/int_sig2.c
@@ -75,7 +75,7 @@ PBSD_sig_put(int c, char *jobid, char *signal, char *extend, int prot, char **ms
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
+		sock = get_svr_shard_connection(c, JOB, jobid, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_sig2.c
+++ b/src/lib/Libifl/int_sig2.c
@@ -75,7 +75,7 @@ PBSD_sig_put(int c, char *jobid, char *signal, char *extend, int prot, char **ms
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, JOB, jobid, &index);
+		sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_status2.c
+++ b/src/lib/Libifl/int_status2.c
@@ -72,10 +72,11 @@ PBSD_status_put(int c, int function, char *id, struct attrl *attrib, char *exten
 {
 	int rc = 0;
 	int sock;
+	int index;
 
 	if (prot == PROT_TCP) {
 		DIS_tcp_funcs();
-		sock = get_svr_shard_connection(c, -1, NULL);
+		sock = get_svr_shard_connection(c, -1, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_status2.c
+++ b/src/lib/Libifl/int_status2.c
@@ -76,7 +76,7 @@ PBSD_status_put(int c, int function, char *id, struct attrl *attrib, char *exten
 
 	if (prot == PROT_TCP) {
 		DIS_tcp_funcs();
-		sock = get_svr_shard_connection(c, -1, NULL, &index);
+		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_status2.c
+++ b/src/lib/Libifl/int_status2.c
@@ -76,7 +76,7 @@ PBSD_status_put(int c, int function, char *id, struct attrl *attrib, char *exten
 
 	if (prot == PROT_TCP) {
 		DIS_tcp_funcs();
-		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+		sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 				return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_submit.c
+++ b/src/lib/Libifl/int_submit.c
@@ -190,7 +190,7 @@ PBSD_rdytocmt(int c, char *jobid, int prot, char **msgid)
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+		sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}
@@ -252,7 +252,7 @@ PBSD_commit(int c, char *jobid, int prot, char **msgid)
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+		sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}
@@ -321,7 +321,7 @@ PBSD_scbuf(int c, int reqtype, int seq, char *buf, int len, char *jobid, enum jo
 
 	if (prot == PROT_TCP) {
 		DIS_tcp_funcs();
-		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+		sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 		if (sock == -1)
 			return (pbs_errno = PBSE_NOCONNECTION);
 	} else {
@@ -535,7 +535,7 @@ PBSD_queuejob(int c, char *jobid, char *destin, struct attropl *attrib, char *ex
 
 	if (prot == PROT_TCP) {
 		DIS_tcp_funcs();
-		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+		sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0) {
 				pbs_errno = PBSE_SYSTEM;

--- a/src/lib/Libifl/int_submit.c
+++ b/src/lib/Libifl/int_submit.c
@@ -190,7 +190,7 @@ PBSD_rdytocmt(int c, char *jobid, int prot, char **msgid)
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL, &index);
+		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}
@@ -252,7 +252,7 @@ PBSD_commit(int c, char *jobid, int prot, char **msgid)
 	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL, &index);
+		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}
@@ -321,7 +321,7 @@ PBSD_scbuf(int c, int reqtype, int seq, char *buf, int len, char *jobid, enum jo
 
 	if (prot == PROT_TCP) {
 		DIS_tcp_funcs();
-		sock = get_svr_shard_connection(c, -1, NULL, &index);
+		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 		if (sock == -1)
 			return (pbs_errno = PBSE_NOCONNECTION);
 	} else {
@@ -535,7 +535,7 @@ PBSD_queuejob(int c, char *jobid, char *destin, struct attropl *attrib, char *ex
 
 	if (prot == PROT_TCP) {
 		DIS_tcp_funcs();
-		sock = get_svr_shard_connection(c, -1, NULL, &index);
+		sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0) {
 				pbs_errno = PBSE_SYSTEM;

--- a/src/lib/Libifl/int_submit.c
+++ b/src/lib/Libifl/int_submit.c
@@ -187,9 +187,10 @@ PBSD_rdytocmt(int c, char *jobid, int prot, char **msgid)
 	int rc;
 	struct batch_reply *reply;
 	int sock;
+	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL);
+		sock = get_svr_shard_connection(c, -1, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}
@@ -248,9 +249,10 @@ PBSD_commit(int c, char *jobid, int prot, char **msgid)
 	struct batch_reply *reply;
 	int rc;
 	int sock;
+	int index;
 
 	if (prot == PROT_TCP) {
-		sock = get_svr_shard_connection(c, -1, NULL);
+		sock = get_svr_shard_connection(c, -1, NULL, &index);
 		if (sock == -1) {
 			return (pbs_errno = PBSE_NOCONNECTION);
 		}
@@ -315,10 +317,11 @@ PBSD_scbuf(int c, int reqtype, int seq, char *buf, int len, char *jobid, enum jo
 	struct batch_reply   *reply;
 	int	rc;
 	int sock;
+	int index;
 
 	if (prot == PROT_TCP) {
 		DIS_tcp_funcs();
-		sock = get_svr_shard_connection(c, -1, NULL);
+		sock = get_svr_shard_connection(c, -1, NULL, &index);
 		if (sock == -1)
 			return (pbs_errno = PBSE_NOCONNECTION);
 	} else {
@@ -528,10 +531,11 @@ PBSD_queuejob(int c, char *jobid, char *destin, struct attropl *attrib, char *ex
 	char *return_jobid = NULL;
 	int rc;
 	int sock;
+	int index;
 
 	if (prot == PROT_TCP) {
 		DIS_tcp_funcs();
-		sock = get_svr_shard_connection(c, -1, NULL);
+		sock = get_svr_shard_connection(c, -1, NULL, &index);
 		if (sock == -1) {
 			if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0) {
 				pbs_errno = PBSE_SYSTEM;

--- a/src/lib/Libifl/int_submit_resv.c
+++ b/src/lib/Libifl/int_submit_resv.c
@@ -73,7 +73,7 @@ PBSD_submit_resv(int connect, char *resv_id, struct attropl *attrib, char *exten
 	int    sock;
 	int    index;
 
-	sock = get_svr_shard_connection(connect, -1, NULL, &index);
+	sock = get_svr_shard_connection(connect, SHARD_UNKNOWN, NULL, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(connect, pbse_to_txt(PBSE_NOCONNECTION)) != 0){
 			pbs_errno = PBSE_SYSTEM;

--- a/src/lib/Libifl/int_submit_resv.c
+++ b/src/lib/Libifl/int_submit_resv.c
@@ -73,7 +73,7 @@ PBSD_submit_resv(int connect, char *resv_id, struct attropl *attrib, char *exten
 	int    sock;
 	int    index;
 
-	sock = get_svr_shard_connection(connect, SHARD_UNKNOWN, NULL, &index);
+	sock = get_svr_shard_connection(connect, OTHERS, NULL, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(connect, pbse_to_txt(PBSE_NOCONNECTION)) != 0){
 			pbs_errno = PBSE_SYSTEM;

--- a/src/lib/Libifl/int_submit_resv.c
+++ b/src/lib/Libifl/int_submit_resv.c
@@ -71,8 +71,9 @@ PBSD_submit_resv(int connect, char *resv_id, struct attropl *attrib, char *exten
 	char  *return_resv_id = NULL;
 	int    rc;
 	int    sock;
+	int    index;
 
-	sock = get_svr_shard_connection(connect, -1, NULL);
+	sock = get_svr_shard_connection(connect, -1, NULL, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(connect, pbse_to_txt(PBSE_NOCONNECTION)) != 0){
 			pbs_errno = PBSE_SYSTEM;

--- a/src/lib/Libifl/int_ucred.c
+++ b/src/lib/Libifl/int_ucred.c
@@ -83,7 +83,7 @@ PBSD_ucred(int c, char *user, int type, char *buf, int len)
 	int	sock;
 	int index;
 
-	sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+	sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_ucred.c
+++ b/src/lib/Libifl/int_ucred.c
@@ -81,8 +81,9 @@ PBSD_ucred(int c, char *user, int type, char *buf, int len)
 	int			rc;
 	struct batch_reply	*reply = NULL;
 	int	sock;
+	int index;
 
-	sock = get_svr_shard_connection(c, -1, NULL);
+	sock = get_svr_shard_connection(c, -1, NULL, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/int_ucred.c
+++ b/src/lib/Libifl/int_ucred.c
@@ -83,7 +83,7 @@ PBSD_ucred(int c, char *user, int type, char *buf, int len)
 	int	sock;
 	int index;
 
-	sock = get_svr_shard_connection(c, -1, NULL, &index);
+	sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_asyrun.c
+++ b/src/lib/Libifl/pbsD_asyrun.c
@@ -69,6 +69,7 @@ __pbs_asyrunjob(int c, char *jobid, char *location, char *extend)
 	struct batch_reply   *reply;
 	unsigned long resch = 0;
 	int	sock;
+	int index;
 
 	if ((jobid == NULL) || (*jobid == '\0'))
 		return (pbs_errno = PBSE_IVALREQ);
@@ -86,7 +87,7 @@ __pbs_asyrunjob(int c, char *jobid, char *location, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, jobid);
+	sock = get_svr_shard_connection(c, JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_asyrun.c
+++ b/src/lib/Libifl/pbsD_asyrun.c
@@ -87,7 +87,7 @@ __pbs_asyrunjob(int c, char *jobid, char *location, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
+	sock = get_svr_shard_connection(c, JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_asyrun.c
+++ b/src/lib/Libifl/pbsD_asyrun.c
@@ -87,7 +87,7 @@ __pbs_asyrunjob(int c, char *jobid, char *location, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, jobid, &index);
+	sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -446,13 +446,14 @@ int internal_client_connect(int vsock, char *server, int port, char *extend_data
  * @param[in]   vsock - The virtual socket used to demux and find the physical server socket
  * @param[in]   obj_type - Caller object type
  * @param[in]   obj_id - Hint used by internal sharding logic
+ * @param[out]  svr_index - server's index
  *
  * @return int
  * @retval >= 0 The physical server socket
  * @retval -1   error encountered setting up the connection
  */
 int 
-get_svr_shard_connection(int vsock, enum pbs_obj_type obj_type, void *obj_id)
+get_svr_shard_connection(int vsock, enum pbs_obj_type obj_type, void *obj_id, int *index)
 {
 	int sd = -1;
 	int i = 0;
@@ -467,6 +468,7 @@ get_svr_shard_connection(int vsock, enum pbs_obj_type obj_type, void *obj_id)
 	max_num_servers = get_max_servers();
 	if (max_num_servers == 1)
 		return vsock;
+		
 	/* below code only for multi-server case */
 	num_of_conf_servers = get_current_servers();
 	if (shard_init_flag == -1) {
@@ -536,6 +538,8 @@ get_svr_shard_connection(int vsock, enum pbs_obj_type obj_type, void *obj_id)
 	} while (!done);
 	free(inact_svr_indexes);
 	set_conn_shard_context(vsock, srv_index);
+	if (index)
+		*index = srv_index;
 	return (shard_connection[srv_index]->sd);
 err:
 	free(inact_svr_indexes);

--- a/src/lib/Libifl/pbsD_defschreply.c
+++ b/src/lib/Libifl/pbsD_defschreply.c
@@ -74,6 +74,7 @@ pbs_defschreply(int c, int cmd, char *id, int err, char *txt, char *extend)
 	struct batch_reply   *reply;
 	int	has_txt = 0;
 	int	sock;
+	int index;
 
 	if ((id == NULL) || (*id == '\0'))
 		return (pbs_errno = PBSE_IVALREQ);
@@ -91,7 +92,7 @@ pbs_defschreply(int c, int cmd, char *id, int err, char *txt, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */	
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, id);
+	sock = get_svr_shard_connection(c, JOB, id, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_defschreply.c
+++ b/src/lib/Libifl/pbsD_defschreply.c
@@ -92,7 +92,7 @@ pbs_defschreply(int c, int cmd, char *id, int err, char *txt, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */	
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, SHARD_JOB, id, &index);
+	sock = get_svr_shard_connection(c, JOB, id, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_defschreply.c
+++ b/src/lib/Libifl/pbsD_defschreply.c
@@ -92,7 +92,7 @@ pbs_defschreply(int c, int cmd, char *id, int err, char *txt, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */	
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, id, &index);
+	sock = get_svr_shard_connection(c, SHARD_JOB, id, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_locjob.c
+++ b/src/lib/Libifl/pbsD_locjob.c
@@ -70,13 +70,14 @@ __pbs_locjob(int c, char *jobid, char *extend)
 	struct batch_reply *reply;
 	char       *ploc = NULL;
 	int sock;
+	int index;
 
 	if ((jobid == NULL) || (*jobid == '\0')) {
 		pbs_errno = PBSE_IVALREQ;
 		return (ploc);
 	}
 
-	sock = get_svr_shard_connection(c, JOB, jobid);
+	sock = get_svr_shard_connection(c, JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0) {
 			pbs_errno = PBSE_SYSTEM;

--- a/src/lib/Libifl/pbsD_locjob.c
+++ b/src/lib/Libifl/pbsD_locjob.c
@@ -77,7 +77,7 @@ __pbs_locjob(int c, char *jobid, char *extend)
 		return (ploc);
 	}
 
-	sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
+	sock = get_svr_shard_connection(c, JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0) {
 			pbs_errno = PBSE_SYSTEM;

--- a/src/lib/Libifl/pbsD_locjob.c
+++ b/src/lib/Libifl/pbsD_locjob.c
@@ -77,7 +77,7 @@ __pbs_locjob(int c, char *jobid, char *extend)
 		return (ploc);
 	}
 
-	sock = get_svr_shard_connection(c, JOB, jobid, &index);
+	sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0) {
 			pbs_errno = PBSE_SYSTEM;

--- a/src/lib/Libifl/pbsD_movejob.c
+++ b/src/lib/Libifl/pbsD_movejob.c
@@ -69,6 +69,7 @@ __pbs_movejob(int c, char *jobid, char *destin, char *extend)
 	int		    rc;
 	struct batch_reply *reply;
 	int		    sock;
+	int 	index;
 
 
 	if ((jobid == NULL) || (*jobid == '\0'))
@@ -78,7 +79,7 @@ __pbs_movejob(int c, char *jobid, char *destin, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, -1, NULL);
+	sock = get_svr_shard_connection(c, -1, NULL, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_movejob.c
+++ b/src/lib/Libifl/pbsD_movejob.c
@@ -79,7 +79,7 @@ __pbs_movejob(int c, char *jobid, char *destin, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+	sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_movejob.c
+++ b/src/lib/Libifl/pbsD_movejob.c
@@ -79,7 +79,7 @@ __pbs_movejob(int c, char *jobid, char *destin, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, -1, NULL, &index);
+	sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_msgjob.c
+++ b/src/lib/Libifl/pbsD_msgjob.c
@@ -73,6 +73,7 @@ __pbs_msgjob(int c, char *jobid, int fileopt, char *msg, char *extend)
 	struct batch_reply *reply;
 	int	rc;
 	int sock;
+	int index;
 
 	if ((jobid == NULL) || (*jobid == '\0') ||
 		(msg == NULL) || (*msg == '\0'))
@@ -89,7 +90,7 @@ __pbs_msgjob(int c, char *jobid, int fileopt, char *msg, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, jobid);
+	sock = get_svr_shard_connection(c, JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);
@@ -218,6 +219,7 @@ char *extend;
 	struct batch_reply *reply;
 	int	rc;
 	int sock;
+	int index;
 
 	if ((jobid == NULL) || (*jobid == '\0') ||
 					(node_list == NULL))
@@ -283,7 +285,7 @@ char *extend;
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, jobid);
+	sock = get_svr_shard_connection(c, JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_msgjob.c
+++ b/src/lib/Libifl/pbsD_msgjob.c
@@ -90,7 +90,7 @@ __pbs_msgjob(int c, char *jobid, int fileopt, char *msg, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, jobid, &index);
+	sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);
@@ -285,7 +285,7 @@ char *extend;
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, jobid, &index);
+	sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_msgjob.c
+++ b/src/lib/Libifl/pbsD_msgjob.c
@@ -90,7 +90,7 @@ __pbs_msgjob(int c, char *jobid, int fileopt, char *msg, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
+	sock = get_svr_shard_connection(c, JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);
@@ -285,7 +285,7 @@ char *extend;
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
+	sock = get_svr_shard_connection(c, JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_orderjo.c
+++ b/src/lib/Libifl/pbsD_orderjo.c
@@ -69,6 +69,7 @@ __pbs_orderjob(int c, char *job1, char *job2, char *extend)
 	struct batch_reply *reply;
 	int rc;
 	int sock;
+	int index;
 
 
 	if ((job1 == NULL) || (*job1 == '\0') ||
@@ -86,7 +87,7 @@ __pbs_orderjob(int c, char *job1, char *job2, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, job1);
+	sock = get_svr_shard_connection(c, JOB, job1, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_orderjo.c
+++ b/src/lib/Libifl/pbsD_orderjo.c
@@ -87,7 +87,7 @@ __pbs_orderjob(int c, char *job1, char *job2, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, SHARD_JOB, job1, &index);
+	sock = get_svr_shard_connection(c, JOB, job1, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_orderjo.c
+++ b/src/lib/Libifl/pbsD_orderjo.c
@@ -87,7 +87,7 @@ __pbs_orderjob(int c, char *job1, char *job2, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, job1, &index);
+	sock = get_svr_shard_connection(c, SHARD_JOB, job1, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_rerunjo.c
+++ b/src/lib/Libifl/pbsD_rerunjo.c
@@ -71,6 +71,7 @@ __pbs_rerunjob(int c, char *jobid, char *extend)
 	struct batch_reply *reply;
 	time_t  old_tcp_timeout;
 	int	sock;
+	int index;
 
 	if ((jobid == NULL) || (*jobid == '\0'))
 		return (pbs_errno = PBSE_IVALREQ);
@@ -86,7 +87,7 @@ __pbs_rerunjob(int c, char *jobid, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, jobid);
+	sock = get_svr_shard_connection(c, JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_rerunjo.c
+++ b/src/lib/Libifl/pbsD_rerunjo.c
@@ -87,7 +87,7 @@ __pbs_rerunjob(int c, char *jobid, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
+	sock = get_svr_shard_connection(c, JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_rerunjo.c
+++ b/src/lib/Libifl/pbsD_rerunjo.c
@@ -87,7 +87,7 @@ __pbs_rerunjob(int c, char *jobid, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, jobid, &index);
+	sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_resc.c
+++ b/src/lib/Libifl/pbsD_resc.c
@@ -143,7 +143,7 @@ PBS_resc(int c, int reqtype, char **rescl, int ct, pbs_resource_t rh)
 	int sock;
 	int index;
 
-	sock = get_svr_shard_connection(c, -1, NULL, &index);
+	sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 	if (sock == -1) {
 		pbs_errno = PBSE_NOCONNECTION;
 		return pbs_errno;

--- a/src/lib/Libifl/pbsD_resc.c
+++ b/src/lib/Libifl/pbsD_resc.c
@@ -143,7 +143,7 @@ PBS_resc(int c, int reqtype, char **rescl, int ct, pbs_resource_t rh)
 	int sock;
 	int index;
 
-	sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+	sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 	if (sock == -1) {
 		pbs_errno = PBSE_NOCONNECTION;
 		return pbs_errno;

--- a/src/lib/Libifl/pbsD_resc.c
+++ b/src/lib/Libifl/pbsD_resc.c
@@ -141,8 +141,9 @@ PBS_resc(int c, int reqtype, char **rescl, int ct, pbs_resource_t rh)
 {
 	int rc;
 	int sock;
+	int index;
 
-	sock = get_svr_shard_connection(c, -1, NULL);
+	sock = get_svr_shard_connection(c, -1, NULL, &index);
 	if (sock == -1) {
 		pbs_errno = PBSE_NOCONNECTION;
 		return pbs_errno;

--- a/src/lib/Libifl/pbsD_runjob.c
+++ b/src/lib/Libifl/pbsD_runjob.c
@@ -70,6 +70,7 @@ __pbs_runjob(int c, char *jobid, char *location, char *extend)
 	struct batch_reply   *reply;
 	unsigned long	resch = 0;
 	int	sock;
+	int index;
 
 	if ((jobid == NULL) || (*jobid == '\0'))
 		return (pbs_errno = PBSE_IVALREQ);
@@ -87,7 +88,7 @@ __pbs_runjob(int c, char *jobid, char *location, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, jobid);
+	sock = get_svr_shard_connection(c, JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_runjob.c
+++ b/src/lib/Libifl/pbsD_runjob.c
@@ -88,7 +88,7 @@ __pbs_runjob(int c, char *jobid, char *location, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, JOB, jobid, &index);
+	sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_runjob.c
+++ b/src/lib/Libifl/pbsD_runjob.c
@@ -88,7 +88,7 @@ __pbs_runjob(int c, char *jobid, char *location, char *extend)
 
 	/* Below reset would force the connection to execute the sharding logic afresh */
 	set_new_shard_context(c);
-	sock = get_svr_shard_connection(c, SHARD_JOB, jobid, &index);
+	sock = get_svr_shard_connection(c, JOB, jobid, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -182,7 +182,7 @@ PBSD_select_put(int c, int type, struct attropl *attrib,
 	int sock;
 	int index;
 
-	sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+	sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -180,8 +180,9 @@ PBSD_select_put(int c, int type, struct attropl *attrib,
 {
 	int rc;
 	int sock;
+	int index;
 
-	sock = get_svr_shard_connection(c, -1, NULL);
+	sock = get_svr_shard_connection(c, -1, NULL, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -182,7 +182,7 @@ PBSD_select_put(int c, int type, struct attropl *attrib,
 	int sock;
 	int index;
 
-	sock = get_svr_shard_connection(c, -1, NULL, &index);
+	sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 	if (sock == -1) {
 		if (set_conn_errtxt(c, pbse_to_txt(PBSE_NOCONNECTION)) != 0)
 			return (pbs_errno = PBSE_SYSTEM);

--- a/src/lib/Libifl/pbsD_stagein.c
+++ b/src/lib/Libifl/pbsD_stagein.c
@@ -76,7 +76,7 @@ pbs_stagein(int c, char *jobid, char *location, char *extend)
 	if (location == NULL)
 		location = "";
 
-	sock = get_svr_shard_connection(c, -1, NULL, &index);
+	sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
 	if (sock == -1) {
 		return (pbs_errno = PBSE_NOCONNECTION);
 	}

--- a/src/lib/Libifl/pbsD_stagein.c
+++ b/src/lib/Libifl/pbsD_stagein.c
@@ -69,13 +69,14 @@ pbs_stagein(int c, char *jobid, char *location, char *extend)
 	int	rc;
 	struct batch_reply   *reply;
 	int	sock;
+	int index;
 
 	if ((jobid == NULL) || (*jobid == '\0'))
 		return (pbs_errno = PBSE_IVALREQ);
 	if (location == NULL)
 		location = "";
 
-	sock = get_svr_shard_connection(c, -1, NULL);
+	sock = get_svr_shard_connection(c, -1, NULL, &index);
 	if (sock == -1) {
 		return (pbs_errno = PBSE_NOCONNECTION);
 	}

--- a/src/lib/Libifl/pbsD_stagein.c
+++ b/src/lib/Libifl/pbsD_stagein.c
@@ -76,7 +76,7 @@ pbs_stagein(int c, char *jobid, char *location, char *extend)
 	if (location == NULL)
 		location = "";
 
-	sock = get_svr_shard_connection(c, SHARD_UNKNOWN, NULL, &index);
+	sock = get_svr_shard_connection(c, OTHERS, NULL, &index);
 	if (sock == -1) {
 		return (pbs_errno = PBSE_NOCONNECTION);
 	}

--- a/src/lib/Libshard/shard_functions.c
+++ b/src/lib/Libshard/shard_functions.c
@@ -68,7 +68,7 @@
 static int max_num_of_servers = 0;
 static server_instance_t **configured_servers = NULL;
 static int configured_num_servers = 0;
-enum shard_obj_type {JOB, RESERVATION, NODE};
+enum shard_obj_type {OTHERS = -1, JOB, RESERVATION, NODE};
 
 #ifdef WIN32
 int gettimeofday(struct timeval * tp, struct timezone * tzp)

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2196,12 +2196,19 @@ int
 get_svr_index(pbs_server_instance_t *instance)
 {
 	int i;
+	char *pc;
+	int len = 0;
 	if (get_max_servers() > 1) {
 		for(i = 0; i < get_current_servers(); i++) {
 			if (instance->port == pbs_conf.psi[i]->port) {
-				if ( (instance->name == NULL) || (pbs_conf.psi[i]->name == NULL) )
+				if ((!instance->name) || (!pbs_conf.psi[i]->name))
 					return  -1;
-				if (strcmp(instance->name, pbs_conf.psi[i]->name) == 0) 
+				pc = strchr(instance->name, (int)'.');
+				if (pc)
+					len = pc - instance->name;
+				else
+					len = strlen(instance->name);
+				if (strncmp(instance->name, pbs_conf.psi[i]->name, len) == 0) 
 					return i;
 			}
 		}

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -58,6 +58,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <netdb.h>
 #include "dis.h"
 #include "libpbs.h"
 #include "list_link.h"
@@ -118,6 +119,7 @@ extern useconds_t	alps_release_jitter;
 #endif
 
 extern char		*path_hooks_workdir;
+extern int		virtual_sock;
 
 #ifndef WIN32
 /**
@@ -1887,6 +1889,59 @@ end_loop:
 
 /**
  * @brief
+ * 	Internal function to open TPP stream to given server info.
+ *
+ * @param[in]	server  - name of Server to which to send the restart
+ * @param[in]	port - port Server would be expecting to receive IM messages
+ * @param[in]	channel - not used 
+ * @param[in]	extend_data - not used
+ * 
+ * @return	int
+ * @retval	-1	 -	If an error occurs.
+ * @retval	!=-1 -  Success, the fd for the APP to use is returned
+ */
+int 
+internal_connect_mom(int channel, char *server, int port, char *extend_data)
+{
+	return tpp_open(server, port);
+}
+
+/**
+ * @brief
+ * 	Initialise the shard connection table and utilize the 
+ *  get_svr_shard_connection() to choose the sharded server.
+ *
+ * @param[in]	svr  - name of Server to which to send the restart
+ * @param[in]	port - port Server would be expecting to receive IM messages
+ * @param[out]	svr_index - server's index
+ *
+ * @return	int
+ * @retval	-1	 -	If an error occurs.
+ * @retval	!=-1 -  Success, the fd for the APP to use is returned
+ */
+int
+get_svr_instance(char *svr, unsigned int port, char *jobid, int *svr_index)
+{
+	int	stream = -1;
+	if (get_max_servers() > 1) {
+		pfn_connect = internal_connect_mom;
+		set_new_shard_context(virtual_sock);
+		stream = get_svr_shard_connection(virtual_sock, JOB, jobid, svr_index);	
+	} else {
+		*svr_index = 0;
+		if (server_stream == -1) {
+			if (svr == NULL)
+				svr = get_servername(&port);
+			stream = tpp_open(svr, port);
+		} else
+			return server_stream;
+	}
+	return stream;
+}
+
+
+/**
+ * @brief
  * 		choosing one server in random if a failover server is already set up.
  *
  * @param[out] port - Passed through to parse_servername(), not modified here.
@@ -1930,6 +1985,8 @@ send_hellosvr(int stream)
 	int		rc = 0;
 	char		*svr = NULL;
 	unsigned int	port = default_server_port;
+	struct	sockaddr_in	*addr;
+	int svr_index;
 
 	DBPRT(("Sending hellosvr"))
 
@@ -1939,12 +1996,14 @@ send_hellosvr(int stream)
 			return;
 		}
 
-		stream = tpp_open(svr, port);
+		stream = get_svr_instance(svr, port, NULL, &svr_index);
 		if (stream < 0) {
 			sprintf(log_buffer, "tpp_open(%s, %d) failed", svr, port);
 			log_err(errno, msg_daemonname, log_buffer);
 			return;
 		}
+		addr = tpp_getaddr(stream);
+		port = ntohs((unsigned short)addr->sin_port);
 	}
 
 	if ((rc = is_compose(stream, IS_HELLOSVR)) != DIS_SUCCESS)

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -1926,7 +1926,7 @@ get_svr_instance(char *svr, unsigned int port, char *jobid, int *svr_index)
 	if (get_max_servers() > 1) {
 		pfn_connect = internal_connect_mom;
 		set_new_shard_context(virtual_sock);
-		stream = get_svr_shard_connection(virtual_sock, SHARD_JOB, jobid, svr_index);	
+		stream = get_svr_shard_connection(virtual_sock, JOB, jobid, svr_index);	
 	} else {
 		*svr_index = 0;
 		if (server_stream == -1) {

--- a/src/resmom/catch_child.c
+++ b/src/resmom/catch_child.c
@@ -1926,7 +1926,7 @@ get_svr_instance(char *svr, unsigned int port, char *jobid, int *svr_index)
 	if (get_max_servers() > 1) {
 		pfn_connect = internal_connect_mom;
 		set_new_shard_context(virtual_sock);
-		stream = get_svr_shard_connection(virtual_sock, JOB, jobid, svr_index);	
+		stream = get_svr_shard_connection(virtual_sock, SHARD_JOB, jobid, svr_index);	
 	} else {
 		*svr_index = 0;
 		if (server_stream == -1) {

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -120,6 +120,7 @@ extern  char   *msg_err_malloc;
 extern int
 write_pipe_data(int upfds, void *data, int data_size);
 char	task_fmt[] = "/%8.8X";
+extern int virtual_sock;
 
 
 /* Function pointers
@@ -2346,6 +2347,39 @@ term_job(job *pjob)
 	del_job_hw(pjob);	/* release special hardware related resources */
 }
 
+
+/**
+ * @brief
+ * find_server_stream - search the given stream in shard connection table 
+ * and returns its index
+ *
+ * @param[in] stream - server index's stream to search
+ *
+ * @return int
+ *
+ * @retval	-1	 -	If an error occurs.
+ * @retval	!=-1 -  Success, the server index in shard connection table.
+ *
+ */
+int
+find_svr_inst_from_stream(int stream)
+{
+	shard_conn_t **shard_connection = NULL;
+	int j;
+
+	shard_connection = (shard_conn_t **)get_conn_shards(virtual_sock);
+	if (!shard_connection) {
+		log_err(-1, __func__, "Invalid shard connection; failed to find the server index");
+		return -1;
+	}
+
+	for (j = 0; j < get_current_servers(); j++) {
+		if (stream == shard_connection[j]->sd)
+			return j;
+	}
+	return -1;
+}
+
 /**
  * @brief
  *	Handle a stream that needs to be closed.
@@ -2364,6 +2398,8 @@ im_eof(int stream, int ret)
 	job			*pjob;
 	hnodent			*np;
 	struct	sockaddr_in	*addr;
+	shard_conn_t **shard_connection = NULL;
+	int svr_index;
 
 	addr = tpp_getaddr(stream);
 	sprintf(log_buffer, "%s from addr %s on stream %d",
@@ -2376,6 +2412,22 @@ im_eof(int stream, int ret)
 		log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_NOTICE,
 			__func__, log_buffer);
 		server_stream = -1;
+	}
+
+	if (get_max_servers() > 1) {
+		shard_connection = (shard_conn_t **)get_conn_shards(virtual_sock);
+		if (!shard_connection) {
+			log_err(-1, __func__, "Invalid shard connection; failed to reset connection state");
+			tpp_close(stream);
+		}
+		if ((svr_index = find_svr_inst_from_stream(stream)) != -1) {
+			snprintf(log_buffer, sizeof(log_buffer), "Server connection closed; changing connection state");
+			log_event(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_NOTICE,
+				__func__, log_buffer);
+			shard_connection[svr_index]->state = SHARD_CONN_STATE_DOWN;
+			shard_connection[svr_index]->state_change_time = time(0);
+			set_new_shard_context(virtual_sock);
+		}
 	}
 
 	/*

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -2350,7 +2350,7 @@ term_job(job *pjob)
 
 /**
  * @brief
- * find_server_stream - search the given stream in shard connection table 
+ * Search the given stream in shard connection table 
  * and returns its index
  *
  * @param[in] stream - server index's stream to search


### PR DESCRIPTION
Describe Bug or Feature
To avoid the oversubscription of the default server, now pbs_mom would connect to any one of the random server (using the get_svr_shard_connection()).

Describe Your Changes

Added new api named get_server_stream() to get the stream to connect the random server, this api would initialize the shard connection table to multiple-servers.
If the initially connected server goes down, PBS_MOM would connect to the next available server for node info updates.
JOB updates would be sent to respective using the same get_server_stream() with the jobid as a hint to find its server.
Added another API set_server_stream(), that helps to update the shard connection table to preserve the new incoming connection from the new stream descriptor to the server index appropriately.
Updated the im_eof network down handler to handle the disconnection from the server and updates its state as DOWN.
