### PR TITLE
Job id fix for multi-server mode

### DIFF
--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -331,7 +331,7 @@ load_svinst_last_jobid(int sv_index)
 			sprintf(log_buffer, "unable to open lastjobid file %s", last_jobidfile);
 			log_err(errno, msg_daemonname, log_buffer);
 		}
-		return (0);
+		return (sv_index);
 	}
 	fscanf(fp, "%lld", &last_jobid);
 	fclose(fp);

--- a/src/server/req_quejob.c
+++ b/src/server/req_quejob.c
@@ -3298,13 +3298,13 @@ get_next_svr_sequence_id(void)
 	server.sv_qs.sv_jobidnumber = 
 		pbs_shard_get_next_seqid(server.sv_qs.sv_jobidnumber, svr_max_job_sequence_id, myindex);
 	
-	if (server.sv_qs.sv_jobidnumber == 0) {
+	if (server.sv_qs.sv_jobidnumber == myindex) {
 		lastid = -1;
 	}
 
 	/* check if we should save jobid increments now */
 	if (lastid == -1 ||  server.sv_qs.sv_jobidnumber == lastid) {
-		lastid = ((server.sv_qs.sv_jobidnumber / 1000)+1)*1000;
+		lastid = pbs_shard_get_next_seqid(((server.sv_qs.sv_jobidnumber / 1000)+1)*1000, svr_max_job_sequence_id, myindex);
 		save_svinst_last_jobid(myindex, lastid);
 	}
 	return next;
@@ -3320,7 +3320,7 @@ get_next_svr_sequence_id(void)
  */
 void reset_svr_sequence_window(void)
 {
-	server.sv_qs.sv_jobidnumber = 0;
+	server.sv_qs.sv_jobidnumber = myindex;
 }
 
 /**

--- a/test/tests/functional/pbs_trillion_jobid.py
+++ b/test/tests/functional/pbs_trillion_jobid.py
@@ -324,21 +324,21 @@ exit 0
         self.submit_resv(resv_id='R2')
         # kill the server forcefully
         self.stop_and_restart_svr('kill')
-        self.submit_job(job_id='1000')
-        self.submit_job(lower=1, upper=2, job_id='1001[]')
-        self.submit_resv(resv_id='R1002')
+        self.submit_job(job_id='1001')
+        self.submit_job(lower=1, upper=2, job_id='1002[]')
+        self.submit_resv(resv_id='R1003')
         # if server gets killed again abruptly then next jobid would be 2000
         self.stop_and_restart_svr('kill')
-        self.submit_job(job_id='2000')
-        self.submit_job(lower=1, upper=2, job_id='2001[]')
-        self.submit_resv(resv_id='R2002')
+        self.submit_job(job_id='2001')
+        self.submit_job(lower=1, upper=2, job_id='2002[]')
+        self.submit_resv(resv_id='R2003')
 
         # Gracefully stop the server so jobid's will continue from the last
         # jobid
         self.stop_and_restart_svr('normal')
-        self.submit_job(job_id='2003')
-        self.submit_job(lower=1, upper=2, job_id='2004[]')
-        self.submit_resv(resv_id='R2005')
+        self.submit_job(job_id='2004')
+        self.submit_job(lower=1, upper=2, job_id='2005[]')
+        self.submit_resv(resv_id='R2006')
 
         # Verify the sequence window, incase of submitting more than 1001 jobs
         # and all jobs should submit successfully without any duplication error
@@ -394,7 +394,7 @@ exit 0
         self.stop_and_restart_svr('kill')
         self.stop_and_restart_svr('kill')
         # Starting at 1000 in current jobid for the sequence window buffer
-        curr_id = 1000
+        curr_id = 1001
         self.submit_job(job_id='%s' % str(curr_id))
         self.submit_job(lower=1, upper=2, job_id='%s[]' % str(curr_id + 1))
         self.submit_resv(resv_id='R%s' % str(curr_id + 2))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
The Jobid sequences for multiple servers are not generating in proper order. 

#### Describe Your Change
Changed the get_next_svr_sequence_id() function for proper seq generation by refering the libshard api.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
[Job_id_seq_test_logs.txt](https://github.com/subhasisb/openpbs/files/4679476/Job_id_seq_test_logs.txt)

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->

TH3 results: No test failure for Jobid 
![image](https://user-images.githubusercontent.com/17980660/82852554-44550f00-9ed1-11ea-8f38-b1353023f8a4.png)

