### PR TITLE
Secondary server starts without stopping primary's active db process

### DIFF
--- a/src/server/pbs_db_func.c
+++ b/src/server/pbs_db_func.c
@@ -419,8 +419,11 @@ get_db_connect_information()
 				if (rc == 0 || rc == 1) /* db running locally or db not running */
 					strncpy(conn_db_host, pbs_conf.pbs_secondary, PBS_MAXSERVERNAME);
 
-				if (rc == 2) /* db could be running on primary, don't start, try connecting to primary's */
+				/* db could be running on primary, don't start, try connecting to primary's */
+				if (rc == 2) { 
 					strncpy(conn_db_host, pbs_conf.pbs_primary, PBS_MAXSERVERNAME);
+					conn_db_state = PBS_DB_STARTED;
+				}
 			}
 		} else {
 			/*


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When the primary server crashed, and Postgres is still running, secondary was starting its own before stopping the Postgres at primary. This used to make Postgres do a panic shutdown. 

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- Before secondary starts its own Postgres, it checks on Primary. pbs_db_status returns 2 when it finds DB running on a different host, in this case, Primary.
- I was not letting secondary know that DB is already running. I added that assignment now.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
