### PR TITLE
Throttle jobs to sched

### DIFF
--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -331,6 +331,7 @@ extern "C" {
 #define ATTR_cred_renew_period	"cred_renew_period"
 #define ATTR_cred_renew_cache_period "cred_renew_cache_period"
 #define ATTR_attr_update_period "attr_update_period"
+#define ATTR_job_stat_limit "job_stat_limit"
 
 /**
  * RPP_MAX_PKT_CHECK_DEFAULT controls the number of loops used to process

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -163,6 +163,7 @@ enum srv_atr {
 	SRV_ATR_rpp_max_pkt_check,
 	SRV_ATR_max_job_sequence_id,
 	SRV_ATR_has_runjob_hook,
+	SRV_ATR_job_stat_limit,
 #if defined(PBS_SECURITY) && (PBS_SECURITY == KRB5)
 	SRV_ATR_acl_krb_realm_enable,
 	SRV_ATR_acl_krb_realms,

--- a/src/lib/Libattr/master_svr_attr_def.xml
+++ b/src/lib/Libattr/master_svr_attr_def.xml
@@ -1689,6 +1689,23 @@
     </member_verify_function>
    </attributes>
    <attributes>
+   /* SRV_ATR_job_stat_limit */
+    <member_name><both>ATTR_job_stat_limit</both></member_name>      <!-- "job_stat_limit" -->
+    <member_at_decode>decode_l</member_at_decode>
+    <member_at_encode>encode_l</member_at_encode>
+    <member_at_set>set_l</member_at_set>
+    <member_at_comp>comp_l</member_at_comp>
+    <member_at_free>free_null</member_at_free>
+    <member_at_action>NULL_FUNC</member_at_action>
+    <member_at_flags><both>MGR_ONLY_SET</both></member_at_flags>
+    <member_at_type><both>ATR_TYPE_LONG</both></member_at_type>
+    <member_at_parent>PARENT_TYPE_SERVER</member_at_parent>
+    <member_verify_function>
+    <ECL>NULL_VERIFY_DATATYPE_FUNC</ECL>
+    <ECL>verify_value_non_zero_positive</ECL>
+    </member_verify_function>
+   </attributes>
+   <attributes>
    /* SRV_ATR_acl_krb_realm_enable */
 	<member_name><both>ATTR_acl_krb_realm_enable</both></member_name>		<!-- "acl_krb_realm_enable" -->
 	<member_at_decode>decode_b</member_at_decode>

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -308,6 +308,30 @@ add_select_array_entries(job *pjob, int dosub, char *statelist,
 }
 
 /**
+ * @brief	helper function to check if job stat limit has been reached
+ *
+ * @param[in,out] count - number of jobs stat'd so far
+ * @param[in] job_limit - the limit
+ *
+ * @return int
+ * @retval 1 if limit has been reached
+ * @retval 0 otherwise
+ */
+static int
+stat_limit_reached(long *count, long job_limit)
+{
+	/* Check job stat limit */
+	if (job_limit > 0) {
+		(*count)++;
+
+		if (*count >= job_limit)
+			return 1;
+	}
+
+	return 0;
+}
+
+/**
  * @brief
  * 		req_selectjobs - service both the Select Job Request and the (special
  *		for the scheduler) Select-status Job Request
@@ -323,19 +347,23 @@ add_select_array_entries(job *pjob, int dosub, char *statelist,
 void
 req_selectjobs(struct batch_request *preq)
 {
-	int		    bad = 0;
-	int		    i;
-	job		   *pjob;
-	svrattrl	   *plist;
-	pbs_queue	   *pque;
+	int bad = 0;
+	int i;
+	job *pjob;
+	svrattrl *plist;
+	pbs_queue *pque;
 	struct batch_reply *preply;
 	struct brp_select **pselx;
-	int		    dosubjobs = 0;
-	int		    dohistjobs = 0;
-	char		   *pstate = NULL;
-	int		    rc;
+	int dosubjobs = 0;
+	int dohistjobs = 0;
+	char *pstate = NULL;
+	int rc;
 	struct select_list *selistp;
-	pbs_sched	   *psched;
+	pbs_sched *psched;
+	long job_limit = 0;
+	long count = 0;
+
+	job_limit = server.sv_attr[SRV_ATR_job_stat_limit].at_val.at_long;
 
 	/*
 	 * if the letter T (or t) is in the extend string,  select subjobs
@@ -447,6 +475,8 @@ req_selectjobs(struct batch_request *preq)
 					}
 
 				}
+				if (stat_limit_reached(&count, job_limit))
+					break;
 			}
 		}
 		if (pque)

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -290,16 +290,16 @@ stat_a_jobidname(struct batch_request *preq, char *name, int dohistjobs, int dos
 
 void req_stat_job(struct batch_request *preq)
 {
-	int		    at_least_one_success = 0;
-	int		    dosubjobs = 0;
-	int		    dohistjobs = 0;
-	char		   *name;
-	job		   *pjob = NULL;
-	pbs_queue	   *pque = NULL;
+	int at_least_one_success = 0;
+	int dosubjobs = 0;
+	int dohistjobs = 0;
+	char *name;
+	job *pjob = NULL;
+	pbs_queue *pque = NULL;
 	struct batch_reply *preply;
-	int		    rc   = 0;
-	int		    type = 0;
-	char		   *pnxtjid = NULL;
+	int rc = 0;
+	int type = 0;
+	char *pnxtjid = NULL;
 
 	/* check for any extended flag in the batch request. 't' for
 	 * the sub jobs. If 'x' is there, then check if the server is


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Adds a new server attribute called "job_stat_limit". By default it's set to 0 to allow normal sites to operate as is. For HTC sites, this should be set accordingly. I think we need to be careful in what number we recommend. If we recommend a smaller number, the scheduler will just take much longer to process the same number of jobs as it would have in a single stat of all jobs. I'd personally recommend setting this number to 100,000/number of servers.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Added a new server attribute, which when set makes it limit the number of jobs sent to scheduler in one cycle.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
