### PR TITLE
Introducing new sched command SCH_SVR_ID 

### DIFF
--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -126,6 +126,7 @@ typedef struct svr_conn {
 	time_t state_change_time;   /* Connnetion state change time */
 	time_t last_used_time;      /* Last used time for the connection */
 	char host_name[256];        /* hostname of the connection coming from */
+	char svr_id[MAX_SVR_ID];    /* svr_id of the form server_name:port */
 } svr_conn_t;
 
 typedef struct pbs_conn {

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -388,6 +388,9 @@ enum accrue_types {
 /* this is the PBS defult jobscript_max_size default value is 100MB*/
 #define DFLT_JOBSCRIPT_MAX_SIZE "100mb"
 
+/* svr_id is of the form sever_name:port. 4 is the lengh of the port, 1 for NULL char */
+#define MAX_SVR_ID (PBS_MAXSERVERNAME + 5)
+
 /* internal attributes */
 #define ATTR_prov_vnode	"prov_vnode"	/* job attribute */
 #define ATTR_ProvisionEnable	"provision_enable"  /* server attribute */

--- a/src/include/sched_cmds.h
+++ b/src/include/sched_cmds.h
@@ -56,8 +56,8 @@
 #define SCH_SCHEDULE_STARTQ 13		/* Stopped queue started */
 #define SCH_SCHEDULE_MVLOCAL 14		/* Job moved to local queue */
 #define SCH_SCHEDULE_ETE_ON 15		/* eligible_time_enable is turned ON */
-#define SCH_SCHEDULE_RESV_RECONFIRM 16		/* Reconfirm a reservation */
-#define SCH_SCHEDULE_RESTART_CYCLE 17		/* Restart a scheduling cycle */
-
+#define SCH_SCHEDULE_RESV_RECONFIRM 16	/* Reconfirm a reservation */
+#define SCH_SCHEDULE_RESTART_CYCLE 17	/* Restart a scheduling cycle */
+#define SCH_SVR_ID 18			/* Used to send server id */
 
 extern int schedule(int cmd, int sd, char *runjid);

--- a/src/scheduler/get_4byte.c
+++ b/src/scheduler/get_4byte.c
@@ -66,10 +66,11 @@
  * @brief
  * 		Gets the Scheduler Command sent by the Server
  *
- * @param[in]	sock	-	socket endpoint to the server
- * @param[in]	val	-	pointer to the value of the scheduler command sent.
- * @param[in]	jid	-	if 'val' obtained is SCH_SCHEDULE_AJOB, then '*jid'
- *						holds the jobid of the job to be scheduled.
+ * @param[in]	sock	- socket endpoint to the server
+ * @param[in]	val	- pointer to the value of the scheduler command sent.
+ * @param[in]	identifier	- if 'val' obtained is SCH_SCHEDULE_AJOB, then "*identifier" is  job id.
+ *				  holds the jobid of the job to be scheduled.
+ *				  else if 'val' obtained is SCH_SVR_ID then '*identifier" is svr_id(server_name:port) of the Server.
  * @return	int
  * @retval	0	: for EOF,
  * @retval	+1	: for success
@@ -81,24 +82,25 @@
  */
 
 int
-get_sched_cmd(int sock, int *val, char **jid)
+get_sched_cmd(int sock, int *val, char **identifier)
 {
-	int	i;
-	int     rc = 0;
-	char	*jobid = NULL;
+	int i;
+	int rc = 0;
+	char *id = NULL;
 
 	DIS_tcp_funcs();
 
 	i = disrsi(sock, &rc);
 	if (rc != 0)
 		goto err;
-	if (i == SCH_SCHEDULE_AJOB) {
-		jobid = disrst(sock, &rc);
+	if (i == SCH_SCHEDULE_AJOB || i == SCH_SVR_ID) {
+		id = disrst(sock, &rc);
 		if (rc != 0)
 			goto err;
-		*jid = jobid;
+		*identifier = id;
 	} else {
-		*jid = NULL;
+		if (identifier != NULL)
+			*identifier = NULL;
 	}
 	*val = i;
 	return 1;

--- a/src/scheduler/globals.c
+++ b/src/scheduler/globals.c
@@ -191,4 +191,4 @@ time_t last_attr_updates = 0;
 
 int send_job_attr_updates = 1;
 
-int svr_id = 0;
+int svr_conn_index = 0;

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -108,7 +108,7 @@ extern time_t last_attr_updates;    /* timestamp of the last time attr updates w
 
 extern int send_job_attr_updates;
 
-extern int svr_id;
+extern int svr_conn_index;
 
 /**
  * @brief

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -150,7 +150,7 @@ extern int chk_save_file(char *filename);
 extern int chk_and_update_db_svrhost();
 #endif /* localmod 005 */
 
-extern int put_sched_cmd(int sock, int cmd, char *jobid);
+extern int put_sched_cmd(int sock, int cmd, char *identifier);
 
 /* External data items */
 extern  pbs_list_head svr_requests;


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Introduce a new scheduling command SCH_SVR_ID to pass "pbs_server_name:port" to Scheduler as soon as the connection establishes.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
host_name of svr_conns table (of type svr_conn_t) is populated as follows in side the scheduler.

```
	if ((phe = gethostbyaddr((char *) &saddr_in.sin_addr, sizeof(saddr_in.sin_addr), AF_INET)) == NULL)  
   	 	return -1;

	strcpy(svr_conns[svr_id]->host_name, phe->h_name);
```
This host_name for all the svr_conns instances remains same if we have n number of different PBS complexes set up in single machine where in we have aliases for the pbs conf parameter PBS_SERVER. 

In order to get the actual pbs_server name and port we introduced the above new scheduling command through which we pass "pbs_server_name:port" which can be stored inside svr_conns table.

Also this information is useful to find out the server that owns a node during run_job of Scheduler and pass the run_job to the that Server.
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

All smoke tests passed.

<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
