### PR TITLE
Enhancing sched to schedule by server

### DIFF
--- a/src/cmds/pbsnodes.c
+++ b/src/cmds/pbsnodes.c
@@ -898,7 +898,7 @@ main(int argc, char *argv[])
 	time_t		     timenow;
 	struct attrl	    *pattr = NULL;
 	int		     con;
-	char		    *def_server;
+	char		    *def_server = NULL;
 	int		     errflg = 0;
 	char		    *errmsg;
 	int		     i;
@@ -927,12 +927,6 @@ main(int argc, char *argv[])
 		return 1;
 	}
 #endif
-
-	/* get default server, may be changed by -s option */
-
-	def_server = pbs_default();
-	if (def_server == NULL)
-		def_server = "";
 
 	if (argc == 1)
 		errflg = 1;
@@ -1080,7 +1074,15 @@ main(int argc, char *argv[])
 		exit(1);
 	}
 
-	setenv(MULTI_SERVER, "ENABLED", 1);
+	if (def_server == NULL) {
+		def_server = pbs_default();
+		if (def_server == NULL)
+			def_server = "";
+
+		/* User didn't specify a server, talk to all */
+		setenv(MULTI_SERVER, "ENABLED", 1);
+	}
+
 	if (CS_client_init() != CS_SUCCESS) {
 		fprintf(stderr, "pbsnodes: unable to initialize security library.\n");
 		exit(1);

--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -1170,12 +1170,14 @@ main(int argc, char **argv)
 
 	if (argc > optind)
 		svrs = strings2objname(&argv[optind], argc - optind, MGR_OBJ_SERVER);
-	else
+	else {
 		svrs = default_server_name();
 
-	/*perform needed security library initializations (including none)*/
+		/* User didn't specify server, talk to all */
+		setenv(MULTI_SERVER, "ENABLED", 1);
+	}
 
-	setenv(MULTI_SERVER, "ENABLED", 1);
+	/*perform needed security library initializations (including none)*/
 	if (CS_client_init() != CS_SUCCESS) {
 		fprintf(stderr, "qmgr: unable to initialize security library.\n");
 		exit(2);

--- a/src/cmds/qselect.c
+++ b/src/cmds/qselect.c
@@ -552,12 +552,13 @@ main(int argc, char **argv, char **envp) /* qselect */
 		if (parse_destination_id(destination, &queue_name_out, &server_name_out)) {
 			fprintf(stderr, "qselect: illegally formed destination: %s\n", destination);
 			exit(2);
-		} else {
-			if (notNULL(server_name_out)) {
-				strncpy(server_out, server_name_out, sizeof(server_out));
-				server_out[sizeof(server_out) - 1] = '\0';
-			}
 		}
+
+		if (notNULL(server_name_out)) {
+			strncpy(server_out, server_name_out, sizeof(server_out));
+			server_out[sizeof(server_out) - 1] = '\0';
+		} else	/* User didn't specify a server, talk to all */
+			setenv(MULTI_SERVER, "ENABLED", 1);
 	}
 
 	/*perform needed security library initializations (including none)*/
@@ -566,7 +567,6 @@ main(int argc, char **argv, char **envp) /* qselect */
 		exit(2);
 	}
 
-	setenv(MULTI_SERVER, "ENABLED", 1);
 	connect = cnt2server(server_out);
 	if (connect <= 0) {
 		fprintf(stderr, "qselect: cannot connect to server %s (errno=%d)\n",

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2732,10 +2732,10 @@ qstat -B [-f] [-F format] [-D delim] [ server_name... ]\n";
 	def_server = pbs_default();
 	if (def_server == NULL)
 		def_server = "";
+	setenv(MULTI_SERVER, "ENABLED", 1);
 	
 	/*perform needed security library initializations (including none)*/
 
-	setenv(MULTI_SERVER, "ENABLED", 1);
 	if (CS_client_init() != CS_SUCCESS)
 		exit_qstat("unable to initialize security library.");
 

--- a/src/cmds/scripts/pbs_add_server
+++ b/src/cmds/scripts/pbs_add_server
@@ -46,6 +46,7 @@ fi
 INST_ID=
 NEW_PBS_CONF=
 NEW_SVR_PORT=
+WITH_MOM=$1
 
 set_new_inst_id() {
 	local _confdir=$(dirname ${PBS_CONF_FILE:-/etc/pbs.conf}) _last_id
@@ -79,7 +80,13 @@ create_new_inst() {
 		echo PBS_START_SCHED=0
 		echo PBS_START_COMM=0
 		echo PBS_START_SERVER=1
-		echo PBS_START_MOM=0
+		if [ ! -z $WITH_MOM ]; then
+			echo PBS_START_MOM=1
+			echo PBS_MOM_SERVICE_PORT=`expr $NEW_SVR_PORT + 10000`
+			echo PBS_MANAGER_SERVICE_PORT=`expr $NEW_SVR_PORT + 10001`
+	    else
+			echo PBS_START_MOM=0
+	    fi
 		echo PBS_BATCH_SERVICE_PORT=${NEW_SVR_PORT}
 		echo PBS_BATCH_SERVICE_PORT_DIS=${NEW_SVR_PORT}
 		echo PBS_DATA_SERVICE_PORT=$((NEW_SVR_PORT + 1))

--- a/src/include/ifl_internal.h
+++ b/src/include/ifl_internal.h
@@ -47,6 +47,8 @@ extern "C" {
 
 #include "pbs_ifl.h"
 
+int add_connection(int);
+
 extern int __pbs_asyrunjob(int, char *, char *, char *);
 
 extern int __pbs_asyrunjob_ack(int c, char *jobid, char *location, char *extend);

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -119,16 +119,6 @@ extern char pbs_current_group[];
 #define SVR_CONN_STATE_CONNECTED 1
 #define SVR_CONN_STATE_FAILED -1
 
-typedef struct svr_conn {
-	int sd;                     /* File descriptor for the open socket */
-	int secondary_sd;           /* Secondary File descriptor for the open socket */
-	int state;                  /* Connection state */
-	time_t state_change_time;   /* Connnetion state change time */
-	time_t last_used_time;      /* Last used time for the connection */
-	char host_name[256];        /* hostname of the connection coming from */
-	char svr_id[MAX_SVR_ID];    /* svr_id of the form server_name:port */
-} svr_conn_t;
-
 typedef struct pbs_conn {
 	int ch_errno;		  /* last error on this connection */
 	char *ch_errtxt;	  /* pointer to last server error text	*/
@@ -145,12 +135,11 @@ int get_conn_errno(int);
 pbs_tcp_chan_t * get_conn_chan(int);
 int set_conn_chan(int, pbs_tcp_chan_t *);
 pthread_mutex_t * get_conn_mutex(int);
-int set_conn_servers(int, void*);
-void * get_conn_servers(int);
-extern svr_conn_t ** initialize_server_conns(int);
 extern int connect_to_servers(char *, uint, char *);
 /* max number of preempt orderings */
 #define PREEMPT_ORDER_MAX 20
+
+void * get_conn_servers(void);
 
 /* PBS Batch Reply Structure */
 
@@ -190,6 +179,8 @@ struct rq_preempt {
 };
 
 typedef struct rq_preempt brp_preempt_jobs;
+
+extern pthread_key_t psi_key;
 
 #define BATCH_REPLY_CHOICE_NULL		1	/* no reply choice, just code */
 #define BATCH_REPLY_CHOICE_Queue	2	/* Job ID, see brp_jid */
@@ -347,7 +338,8 @@ extern struct batch_reply *PBSD_rdrpy(int);
 extern struct batch_reply *PBSD_rdrpy_sock(int, int *);
 extern void PBSD_FreeReply(struct batch_reply *);
 extern struct batch_status *PBSD_status(int, int, char *, struct attrl *, char *);
-extern int random_srv_conn(svr_conn_t **);
+extern int random_srv_conn(svr_conn_t *);
+extern int get_available_conn(svr_conn_t *svr_connections);
 extern struct batch_status *PBSD_status_aggregate(int, int, char *, struct attrl *, char *, int);
 extern struct batch_status *PBSD_status_random(int, int, char *, struct attrl *, char *, int);
 extern preempt_job_info *PBSD_preempt_jobs(int, char **);

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -350,11 +350,11 @@ void encode_SHA(char*, size_t, char **);
 #endif
 #endif
 
-int get_max_servers(void);
-
 /**
  * Getter function to get the number of currently configured servers.
  */
-extern int get_current_servers();
+extern int get_num_servers();
+
+extern int parse_pbs_name_port(char *svr_id, char *svrname, int *svrport);
 
 extern int rand_num();

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -471,7 +471,8 @@ enum mgr_obj {
 #define PBS_MAXQUEUENAME	15		/* max queue name length */
 #define PBS_MAXJOBNAME  	230		/* max job name length */
 #define PBS_MAXSERVERNAME	PBS_MAXHOSTNAME	/* max server name length */
-#define PBS_MAX_SRV_INSTANCE	PBS_MAXHOSTNAME+PBS_MAXPORTNUM+2	/* max server instance length */
+/* svr_id is of the form sever_name:port. 4 is the lengh of the port, 1 for NULL char */
+#define MAX_SVR_ID (PBS_MAXSERVERNAME + 5)
 #define PBS_MAXSEQNUM		12		/* max sequence number length */
 #define PBS_DFLT_MAX_JOB_SEQUENCE_ID 9999999	/* default value of max_job_sequence_id server attribute */
 #define PBS_MAXPORTNUM	5		/* udp/tcp port numbers max=16 bits */
@@ -566,6 +567,18 @@ typedef struct preempt_job_info {
         char	job_id[PBS_MAXSVRJOBID + 1];
         char	order[PREEMPT_METHOD_HIGH + 1];
 } preempt_job_info;
+
+typedef struct svr_conn {
+	int sd;                     	/* File descriptor for the open socket */
+	int secondary_sd;           	/* Secondary File descriptor for the open socket */
+	int state;                  	/* Connection state */
+	time_t state_change_time;   	/* Connnetion state change time */
+	time_t last_used_time;      	/* Last used time for the connection */
+	char host_name[256];        	/* hostname of the connection coming from */
+	char svr_id[MAX_SVR_ID];    	/* svr_id of the form server_name:port */
+	char name[PBS_MAXHOSTNAME];	/* server name */
+	int port;						/* server port */
+} svr_conn_t;
 
 /* Resource Reservation Information */
 typedef int	pbs_resource_t;	/* resource reservation handle */

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -195,11 +195,11 @@ extern "C" {
 #define MAX_ALLOWED_SVRS 100
 
 /* Structure to store each server instance details */
-struct pbs_server_instance 
+typedef struct pbs_server_instance
 {
-	char *name;
+	char name[PBS_MAXHOSTNAME];
 	int port;
-};
+} pbs_server_instance;
 
 struct pbs_config
 {
@@ -227,8 +227,8 @@ struct pbs_config
 	char *pbs_exec_path;			/* path to the pbs exec dir */
 	char *pbs_server_name;		/* name of PBS Server, usually hostname of host on which PBS server is executing */
 	char *pbs_server_id;                  /* name of the database PBS server id associated with the server hostname, pbs_server_name */
-	unsigned int pbs_current_servers;	/* currently configured number of instances */
-	struct  pbs_server_instance **psi;	/* list of pbs server instances loaded from comma separated host:port[,host:port] */
+	unsigned int pbs_num_servers;	/* currently configured number of instances */
+	pbs_server_instance *psi;	/* array of pbs server instances loaded from comma separated host:port[,host:port] */
 	char *scp_path;			/* path to ssh */
 	char *rcp_path;			/* path to pbs_rsh */
 	char *pbs_demux_path;			/* path to pbs demux */
@@ -389,9 +389,6 @@ enum accrue_types {
 
 /* this is the PBS defult jobscript_max_size default value is 100MB*/
 #define DFLT_JOBSCRIPT_MAX_SIZE "100mb"
-
-/* svr_id is of the form sever_name:port. 4 is the lengh of the port, 1 for NULL char */
-#define MAX_SVR_ID (PBS_MAXSERVERNAME + 5)
 
 /* internal attributes */
 #define ATTR_prov_vnode	"prov_vnode"	/* job attribute */
@@ -572,7 +569,6 @@ extern char *convert_time(char *);
 extern struct batch_status *bs_isort(struct batch_status *bs,
 	int (*cmp_func)(struct batch_status*, struct batch_status *));
 extern struct batch_status *bs_find(struct batch_status *, const char *);
-
 
 #endif /* _USRDLL */
 

--- a/src/lib/Libattr/master_job_attr_def.xml
+++ b/src/lib/Libattr/master_job_attr_def.xml
@@ -221,7 +221,7 @@
       <member_at_comp>comp_str</member_at_comp>
       <member_at_free>free_str</member_at_free>
       <member_at_action>NULL_FUNC</member_at_action>
-      <member_at_flags>READ_ONLY | ATR_DFLAG_MOM</member_at_flags>
+      <member_at_flags>ATR_DFLAG_SvWR | ATR_DFLAG_MOM | ATR_DFLAG_MGRD</member_at_flags>
       <member_at_type>ATR_TYPE_STR</member_at_type>
       <member_at_parent>PARENT_TYPE_JOB</member_at_parent>
       <member_verify_function>

--- a/src/lib/Libattr/master_node_attr_def.xml
+++ b/src/lib/Libattr/master_node_attr_def.xml
@@ -680,7 +680,7 @@
       <member_at_comp>comp_str</member_at_comp>
       <member_at_free>free_str</member_at_free>
       <member_at_action>NULL_FUNC</member_at_action>
-      <member_at_flags>ATR_DFLAG_MGRD | ATR_DFLAG_MGWR</member_at_flags>
+      <member_at_flags>ATR_DFLAG_MGRD | ATR_DFLAG_SvWR</member_at_flags>
       <member_at_type>ATR_TYPE_STR</member_at_type>
       <member_at_parent>PARENT_TYPE_NODE</member_at_parent>
       <member_verify_function>

--- a/src/lib/Libifl/int_status.c
+++ b/src/lib/Libifl/int_status.c
@@ -134,13 +134,13 @@ encode_states(char **val, long *cur, long *nxt)
  *
  */
 int
-get_available_conn(svr_conn_t **svr_connections)
+get_available_conn(svr_conn_t *svr_connections)
 {
 	int i;
 
-	for (i = 0; i < get_current_servers(); i++)
-		if (svr_connections[i] && svr_connections[i]->state == SVR_CONN_STATE_CONNECTED)
-			return svr_connections[i]->sd;
+	for (i = 0; i < get_num_servers(); i++)
+		if (svr_connections[i].state == SVR_CONN_STATE_CONNECTED)
+			return svr_connections[i].sd;
 
 	return -1;
 }
@@ -151,14 +151,14 @@ get_available_conn(svr_conn_t **svr_connections)
  *
  */
 int
-random_srv_conn(svr_conn_t **svr_connections)
+random_srv_conn(svr_conn_t *svr_connections)
 {
 	int ind = 0;
 
-	ind =  rand_num() % get_current_servers();
+	ind =  rand_num() % get_num_servers();
 
-	if (svr_connections[ind] && svr_connections[ind]->state == SVR_CONN_STATE_CONNECTED)
-		return svr_connections[ind]->sd;
+	if (svr_connections[ind].state == SVR_CONN_STATE_CONNECTED)
+		return svr_connections[ind].sd;
 		
 	return get_available_conn(svr_connections);
 }
@@ -417,7 +417,7 @@ PBSD_status_aggregate(int c, int cmd, char *id, struct attrl *attrib, char *exte
 	struct batch_status *ret = NULL;
 	struct batch_status *next = NULL;
 	struct batch_status *cur = NULL;
-	svr_conn_t **svr_connections = get_conn_servers(c);
+	svr_conn_t *svr_connections = get_conn_servers();
 
 	if (!svr_connections)
 		return NULL;
@@ -431,12 +431,11 @@ PBSD_status_aggregate(int c, int cmd, char *id, struct attrl *attrib, char *exte
 		parent_object, MGR_CMD_NONE, (struct attropl *) attrib)))
 		return NULL;
 
-	for (i = 0; i < get_current_servers(); i++) {
-		
-		if ((svr_connections[i] == NULL) || svr_connections[i]->state != SVR_CONN_STATE_CONNECTED)
+	for (i = 0; i < get_num_servers(); i++) {
+		if (svr_connections[i].state != SVR_CONN_STATE_CONNECTED)
 			continue;
 
-		c = svr_connections[i]->sd;
+		c = svr_connections[i].sd;
 
 		if (pbs_client_thread_lock_connection(c) != 0)
 			return NULL;
@@ -492,7 +491,7 @@ struct batch_status *
 PBSD_status_random(int c, int cmd, char *id, struct attrl *attrib, char *extend, int parent_object)
 {
 	struct batch_status *ret = NULL;
-	svr_conn_t **svr_connections = get_conn_servers(c);
+	svr_conn_t *svr_connections = get_conn_servers();
 
 	if (!svr_connections)
 		return NULL;

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -61,6 +61,7 @@
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <netinet/in.h>
+#include <pthread.h>
 #ifndef WIN32
 #include <netinet/tcp.h>
 #endif
@@ -74,6 +75,9 @@
 #include "pbs_internal.h"
 #include "log.h"
 #include "auth.h"
+#include "ifl_internal.h"
+
+extern pthread_key_t psi_key;
 
 /**
  * @brief
@@ -401,37 +405,78 @@ tcp_connect(char *server, int server_port, char *extend_data)
 
 /**
  * @brief
- * 	initialize_server_conns - To intialize the servers connection table.
+ * 	get_conn_servers - get the array of server connections
  *
- * @param[in] num_conf_servers 
+ * @param	void
  *
- * @return svr_conn_t **
- * @retval !NULL - success
- * @retval NULL - error
+ * @return	void
+ * @retval	!NULL - success
+ * @retval	NULL - error
+ *
+ * @par Side Effects:
+ *	None
+ *
+ * @par MT-safe: Yes
  */
-svr_conn_t ** 
-initialize_server_conns(int num_conf_servers)
+void *
+get_conn_servers(void)
 {
-	int i;
-	int j;
-	svr_conn_t **svr_connections = calloc(MAX_ALLOWED_SVRS, sizeof(svr_conn_t *));
+	svr_conn_t *conn_arr = NULL;
 
-	if (!svr_connections)
-		return NULL;
-		
-	for (i = 0; i < num_conf_servers; i++) {
-		svr_connections[i] = malloc(sizeof(svr_conn_t));
-		if (!svr_connections[i]) {
-			for (j = 0; j < i; j++ )
-				free(svr_connections[j]);
-			free(svr_connections);
+	conn_arr = pthread_getspecific(psi_key);
+	if (conn_arr == NULL && pbs_conf.psi != NULL) {
+		int num_svrs;
+		int i;
+
+		num_svrs = get_num_servers();
+		conn_arr = calloc(num_svrs, sizeof(svr_conn_t));
+		if (conn_arr == NULL) {
+			pbs_errno = PBSE_SYSTEM;
 			return NULL;
 		}
-		svr_connections[i]->sd = -1;
-		svr_connections[i]->state = SVR_CONN_STATE_DOWN;
+
+		for (i = 0; i < num_svrs; i++) {
+			strcpy(conn_arr[i].name, pbs_conf.psi[i].name);
+			conn_arr[i].port = pbs_conf.psi[i].port;
+			conn_arr[i].sd = -1;
+			conn_arr[i].secondary_sd = -1;
+			conn_arr[i].state = SVR_CONN_STATE_DOWN;
+		}
+
+		pthread_setspecific(psi_key, conn_arr);
 	}
-	
-	return svr_connections;
+
+	return conn_arr;
+}
+
+
+/**
+ * @brief	Helper function for connect_to_servers to connect to a particular server
+ *
+ * @param[in]		idx - array index for the server to connect to
+ * @param[in,out]	conn_arr - array of svr_conn_t
+ * @param[in]		extend_data - any additional data relevant for connection
+ *
+ * @return	int
+ * @retval	-1 for error
+ * @retval	fd of connection
+ */
+static int
+connect_to_server(int idx, svr_conn_t *conn_arr, char *extend_data)
+{
+	if (conn_arr[idx].state != SVR_CONN_STATE_CONNECTED) {
+		if ((conn_arr[idx].sd =
+				tcp_connect(conn_arr[idx].name, conn_arr[idx].port, extend_data)) != -1) {
+			conn_arr[idx].state = SVR_CONN_STATE_CONNECTED;
+			pbs_client_thread_lock_conntable();
+			add_connection(conn_arr[idx].sd);
+			pbs_client_thread_unlock_conntable();
+		}
+		else
+			conn_arr[idx].state = SVR_CONN_STATE_FAILED;
+	}
+
+	return conn_arr[idx].sd;
 }
 
 /**
@@ -439,7 +484,9 @@ initialize_server_conns(int num_conf_servers)
  * 	To connect to all the servers, fill up the connection table 
  * 	and returns the first connected socket.
  *
- * @param[in] extend_data 
+ * @param[in]	server_name - name of the server to connect to (NULL if not known)
+ * @param[in]	port - port of the server to connect to (considered if server_name is not NULL)
+ * @param[in]	extend_data
  *
  * @return int
  * @retval >0 - success
@@ -452,61 +499,42 @@ connect_to_servers(char *server_name, uint port, char *extend_data)
 	int fd = -1;
 	int start = -1;
 	int multi_flag = 0;
-	int num_conf_servers = get_current_servers();
+	int num_conf_servers = get_num_servers();
 
 	multi_flag = getenv(MULTI_SERVER) != NULL;
 
-	svr_conn_t **svr_connections = calloc(num_conf_servers, sizeof(svr_conn_t *));
-	if (!svr_connections)
+	svr_conn_t *svr_connections = get_conn_servers();
+
+	if (svr_connections == NULL)
 		return -1;
 
 	if (!multi_flag) {
 		if (server_name) {
-			for (i = 0; i < get_current_servers(); i++) {
-				if (!strcmp(server_name, pbs_conf.psi[i]->name) && port == pbs_conf.psi[i]->port) {
+			for (i = 0; i < num_conf_servers; i++) {
+				if (!strcmp(server_name, pbs_conf.psi[i].name) && port == pbs_conf.psi[i].port) {
 					start = i;
 					break;
 				}
 			}
 		}
 		if (start == -1)
-			start = rand_num() % get_current_servers();
+			start = rand_num() % num_conf_servers;
 	}
 	else
 		start = 0;
 
 	i = start;
 	do {
-		if (!svr_connections[i]) {
-			if (!(svr_connections[i] = malloc(sizeof(svr_conn_t))))
-				goto err;
-		}
-
-		if ((svr_connections[i]->sd = tcp_connect(pbs_conf.psi[i]->name, pbs_conf.psi[i]->port, extend_data)) != -1) {
-			svr_connections[i]->state = SVR_CONN_STATE_CONNECTED;
-			fd = svr_connections[i]->sd;
-			if (!multi_flag)
-				break;
-		} else
-			svr_connections[i]->state = SVR_CONN_STATE_FAILED;
+		fd = connect_to_server(i, svr_connections, extend_data);
+		if (svr_connections[i].state == SVR_CONN_STATE_CONNECTED && !multi_flag)
+			break;
 
 		i++;
 		if (i >= num_conf_servers)
 			i = 0;
 	} while (i != start);
 
-	if (set_conn_servers(fd, (void *)svr_connections))
-		return -1;
-
 	return fd;
-
-err:
-	/* free svr_connections array and return */
-	for (i = 0; i < num_conf_servers; i++)
-		free(svr_connections[i]);
-
-	free(svr_connections);
-	return -1;
 }
 
 /**
@@ -554,18 +582,16 @@ __pbs_connect_extend(char *server, char *extend_data)
 	if (pbs_loadconf(0) == 0)
 		return -1;
 
-	/* get server host and port	*/
-
 	server = PBS_get_server(server, server_name, &server_port);
-	if (server == NULL) {
-		pbs_errno = PBSE_NOSERVER;
-		return -1;
-	}
-		
+ 	if (server == NULL) {
+ 		pbs_errno = PBSE_NOSERVER;
+ 		return -1;
+ 	}
+
 	if ((sock = connect_to_servers(server_name, server_port, extend_data)) == -1) {
 		pbs_errno = PBSE_INTERNAL;
 		return -1;
-	}		
+	}
 	
 	/* Returning here  */
 	

--- a/src/lib/Libifl/pbsD_submit.c
+++ b/src/lib/Libifl/pbsD_submit.c
@@ -88,10 +88,11 @@ pbs_submit_with_cred(int c, struct attropl  *attrib, char *script,
 			char *destination, char  *extend, int credtype,
 			size_t credlen, char  *credbuf)
 {
-	char					*ret;
-	struct pbs_client_thread_context	*ptr;
-	struct cred_info			*cred_info;
-	svr_conn_t **svr_connections = get_conn_servers(c);
+	char *ret;
+	struct pbs_client_thread_context *ptr;
+	struct cred_info *cred_info;
+	svr_conn_t *svr_connections = get_conn_servers();
+
 	c = random_srv_conn(svr_connections);
 
 	/* initialize the thread context data, if not already initialized */
@@ -166,7 +167,7 @@ __pbs_submit(int c, struct attropl  *attrib, char *script, char *destination, ch
 	struct cred_info *cred_info = NULL;
 	int commit_done = 0;
 	char *lextend = NULL;
-	svr_conn_t **svr_connections = get_conn_servers(c);
+	svr_conn_t *svr_connections = get_conn_servers();
 	c = random_srv_conn(svr_connections);
 
 	/* initialize the thread context data, if not already initialized */

--- a/src/lib/Libifl/pbs_ifl_wrap.c
+++ b/src/lib/Libifl/pbs_ifl_wrap.c
@@ -7967,7 +7967,7 @@ extern "C" {
       size_t size = strlen(name)+1;
       gv->name = (char *)malloc(size);
       if (gv->name) {
-        memcpy(gv->name, name, size);
+        memcpy(gv->name, name, size - 1);
         gv->get_attr = get_attr;
         gv->set_attr = set_attr;
         gv->next = v->vars;

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2202,13 +2202,50 @@ get_msvr_mode(void)
 
 /**
  * @brief
- *	get_current_servers - Getter function to get number of servers configured in PBS complex.
+ *	get_num_servers - Getter function to get number of servers configured in PBS complex.
  *
  */
 int
-get_current_servers()
+get_num_servers()
 {
-	return pbs_conf.pbs_current_servers;
+	return pbs_conf.pbs_num_servers;
+}
+
+/**
+ * @brief	Get the server name and port number from svrname:port string
+ *
+ * @param[in]	svr_id - id in the format server_name:port
+ * @param[out]	svrname - buffer to store server name
+ * @param[out]	svrport - buffer to store port number
+ *
+ * @return	int
+ * @retval	0 for success
+ * @retval	1 for error
+ */
+int
+parse_pbs_name_port(char *svr_id, char *svrname, int *svrport)
+{
+	char *ptr = NULL;
+	char *endptr;
+	long port = PBS_BATCH_SERVICE_PORT;
+
+	if (svr_id == NULL || svrname == NULL || svrport == NULL)
+		return 1;
+
+	ptr = strchr(svr_id, ':');
+	if (ptr != NULL) {
+		*ptr = '\0';
+		port = strtol(ptr + 1, &endptr, 10);
+		if (*endptr != '\0')
+			return 1;
+	}
+	*svrport = (int) port;
+	snprintf(svrname, PBS_MAXHOSTNAME, "%s", svr_id);
+
+	if (ptr != NULL)
+		*ptr = ':';
+
+	return 0;
 }
 
 /**

--- a/src/scheduler/buckets.c
+++ b/src/scheduler/buckets.c
@@ -261,7 +261,8 @@ free_node_bucket(node_bucket *nb) {
 
 /* node bucket array destructor */
 void
-free_node_bucket_array(node_bucket **buckets) {
+free_node_bucket_array(node_bucket **buckets)
+{
 	int i;
 
 	if (buckets == NULL)
@@ -873,7 +874,9 @@ bucket_to_nspecs(status *policy, chunk_map **cb_map, resource_resv *resresv)
  * @retval 1 if the job should use the bucket algorithm
  * @retval 0 if not
  */
-int job_should_use_buckets(resource_resv *resresv) {
+int
+job_should_use_buckets(resource_resv *resresv)
+{
 
 	if (resresv == NULL)
 		return 0;

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -180,7 +180,7 @@ int add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo, resource
  *	       first move it to the local server and then run it.
  *	       if it's a local job, just run it.
  */
-int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, schd_error *err, char *svr_of_node);
+int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, schd_error *err, int svr_of_node);
 /*
  *	should_backfill_with_job - should we call add_job_to_calendar() with job
  *	returns 1: we should backfill 0: we should not

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -102,6 +102,7 @@
 #include <pbs_ifl.h>
 #include <log.h>
 #include <libutil.h>
+#include <libpbs.h>
 #include <pbs_share.h>
 #include <pbs_internal.h>
 #include <pbs_error.h>
@@ -1216,6 +1217,13 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 			resresv->job->NAS_pri = resresv->job->priority;
 #endif /* localmod 045 */
 		}
+		else if (!strcmp(attrp->name, ATTR_server)) {
+			resresv->svr_index = get_svr_index(attrp->value);
+			if (resresv->svr_index == -1) {
+				free_resource_resv(resresv);
+				return NULL;
+			}
+		}
 		else if (!strcmp(attrp->name, ATTR_qtime)) { /* queue time */
 			count = strtol(attrp->value, &endp, 10);
 			if (*endp == '\0')
@@ -1246,9 +1254,6 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 		}
 		else if (!strcmp(attrp->name, ATTR_N))		/* job name (qsub -N) */
 			resresv->job->job_name = string_dup(attrp->value);
-
-		else if (!strcmp(attrp->name, ATTR_server))
-			resresv->job->svr_name = string_dup(attrp->value);
 
 		else if (!strcmp(attrp->name, ATTR_state)) { /* state of job */
 			if (set_job_state(attrp->value, resresv->job) == 0) {
@@ -1483,9 +1488,6 @@ new_job_info()
 	jinfo->resreq_rel = NULL;
 	jinfo->depend_job_str = NULL;
 	jinfo->dependent_jobs = NULL;
-	jinfo->svr_name = NULL;
-
-
 	jinfo->formula_value = 0.0;
 
 #ifdef RESC_SPEC
@@ -1546,9 +1548,6 @@ free_job_info(job_info *jinfo)
 
 	if (jinfo->dependent_jobs != NULL)
 		free(jinfo->dependent_jobs);
-
-	if (jinfo->svr_name != NULL)
-		free(jinfo->svr_name);
 
 	free_resource_req_list(jinfo->resused);
 
@@ -1772,7 +1771,7 @@ update_job_attr(int pbs_sd, resource_resv *resresv, char *attr_name,
 
 	if (pattr != NULL && (flags & UPDATE_NOW)) {
 		int rc;
-		rc = send_attr_updates(pbs_sd, resresv->name, pattr);
+		rc = send_attr_updates(pbs_sd, resresv, pattr);
 		free_attrl_list(pattr);
 		return rc;
 	}
@@ -1789,14 +1788,15 @@ update_job_attr(int pbs_sd, resource_resv *resresv, char *attr_name,
  *      call is so that the job's attr_updates list gets free'd and NULL'd.
  *      We don't want to send the attr updates multiple times
  *
- * @param[in]	pbs_sd	-	server connection descriptor
+ * @param[in]	pbs_sd	-	the connection descriptor to the server
  * @param[in]	job	-	job to send attributes to
  *
  * @return	int(ret val from send_attr_updates)
  * @retval	1	- success
  * @retval	0	- failure to update
  */
-int send_job_updates(int pbs_sd, resource_resv *job)
+int
+send_job_updates(int pbs_sd, resource_resv *job)
 {
 	int rc;
 	struct attrl *iter_attr = NULL;
@@ -1816,7 +1816,7 @@ int send_job_updates(int pbs_sd, resource_resv *job)
 			return 0;
 	}
 
-	rc = send_attr_updates(pbs_sd, job->name, job->job->attr_updates);
+	rc = send_attr_updates(pbs_sd, job, job->job->attr_updates);
 
 	free_attrl_list(job->job->attr_updates);
 	job->job->attr_updates = NULL;
@@ -1837,12 +1837,14 @@ int send_job_updates(int pbs_sd, resource_resv *job)
  * @retval	0	failure to update
  */
 int
-send_attr_updates(int pbs_sd, char *job_name, struct attrl *pattr)
+send_attr_updates(int pbs_sd, resource_resv *job, struct attrl *pattr)
 {
 	char *errbuf;
 	int one_attr = 0;
+	char *job_name;
+	svr_conn_t *svr_conn = get_conn_servers();
 
-	if (job_name == NULL || pattr == NULL)
+	if (job == NULL || pattr == NULL || svr_conn == NULL)
 		return 0;
 
 	if (pbs_sd == SIMULATE_SD)
@@ -1851,6 +1853,9 @@ send_attr_updates(int pbs_sd, char *job_name, struct attrl *pattr)
 	if (pattr->next == NULL)
 		one_attr = 1;
 
+	job_name = job->name;
+
+	pbs_sd = svr_conn[job->svr_index].sd;
 	if (pbs_asyalterjob(pbs_sd, job_name, pattr, NULL) == 0) {
 		last_attr_updates = time(NULL);
 		return 1;
@@ -2861,8 +2866,6 @@ dup_job_info(job_info *ojinfo, queue_info *nqinfo, server_info *nsinfo)
 
 	njinfo->depend_job_str = string_dup(njinfo->depend_job_str);
 
-	njinfo->svr_name = string_dup(ojinfo->svr_name);
-
 #ifdef RESC_SPEC
 	njinfo->rspec = dup_rescspec(ojinfo->rspec);
 #endif
@@ -3379,6 +3382,7 @@ find_jobs_to_preempt(status *policy, resource_resv *hjob, server_info *sinfo, in
 			}
 		}
 	}
+
 
 	/* use locally dup'd copy of sinfo so we don't modify the original */
 	if ((nsinfo = dup_server_info(sinfo)) == NULL) {

--- a/src/scheduler/job_info.h
+++ b/src/scheduler/job_info.h
@@ -90,7 +90,7 @@ update_job_attr(int pbs_sd, resource_resv *resresv, char *attr_name,
 int send_job_updates(int pbs_sd, resource_resv *job);
 
 /* send delayed attributes to the server for a job */
-int send_attr_updates(int pbs_sd, char *job_name, struct attrl *pattr);
+int send_attr_updates(int pbs_sd, resource_resv *job, struct attrl *pattr);
 
 
 /*

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -106,6 +106,7 @@
 #include "fairshare.h"
 #include "resource_resv.h"
 #include "resource.h"
+#include "libpbs.h"
 
 
 /**
@@ -1645,8 +1646,8 @@ get_svr_index(char *svrname)
 	int i;
 	int svrindex = -1;
 
-	for (i = 0; i < pbs_conf.pbs_current_servers; i++) {
-		if (strcmp(pbs_conf.psi[i]->name, svrname) == 0) {
+	for (i = 0; i < get_num_servers(); i++) {
+		if (strcmp(pbs_conf.psi[i].name, svrname) == 0) {
 			svrindex = i;
 			break;
 		}

--- a/src/scheduler/node_info.h
+++ b/src/scheduler/node_info.h
@@ -70,6 +70,7 @@ free_node_info_chunk(th_data_free_ninfo *data);
  */
 void free_nodes(node_info **ninfo_arr);
 
+int group_nodes_by_svr(node_info **ninfo_arr, server_info *sinfo, int num_nodes);
 
 /*
  *      new_node_info - allocates a new node_info

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -302,42 +302,33 @@ server_disconnect(int connect)
  *
  */
 static void
-close_server_conn(int index_to_shards)
+close_server_conn(int svr_index)
 {
+	svr_conn_t *svr_conns = NULL;
 
-	svr_conn_t **svr_conns = NULL;
+	svr_conns = get_conn_servers();
 
-	pbs_client_thread_lock_connection(entry_to_svr_conns);
-
-	svr_conns = (svr_conn_t **)get_conn_servers(entry_to_svr_conns);
-
-	if (!svr_conns) {
-		/* unlock the connection level lock */
-		pbs_client_thread_unlock_connection(entry_to_svr_conns);
+	if (!svr_conns)
 		return;
-	}
 
-	if (svr_conns[index_to_shards] &&
-			svr_conns[index_to_shards]->state == SVR_CONN_STATE_CONNECTED) {
-		FD_CLR(svr_conns[index_to_shards]->sd , &master_fdset);
-
-		if (svr_conns[index_to_shards]->sd >= 0) {
-			close_tcp_connection(svr_conns[index_to_shards]->sd);
+	if (svr_conns[svr_index].state == SVR_CONN_STATE_CONNECTED) {
+		FD_CLR(svr_conns[svr_index].sd , &master_fdset);
+		if (svr_conns[svr_index].sd >= 0) {
+			close_tcp_connection(svr_conns[svr_index].sd);
 			/* unlock the connection level lock */
-			svr_conns[index_to_shards]->sd = -1;
-			if (svr_conns[index_to_shards]->secondary_sd >= 0) {
+			svr_conns[svr_index].sd = -1;
+			if (svr_conns[svr_index].secondary_sd >= 0) {
 				/* We no need to call close_tcp_connection() once again on secondary connection
 				   It is because PBS_BATCH_Disconnect is sent as part of close_tcp_connection on primary.
 				   The other reason is Server is just expecting only end of cycle on secondary connection 
 				*/ 
-				CS_close_socket(svr_conns[index_to_shards]->secondary_sd);
-				CLOSESOCKET(svr_conns[index_to_shards]->secondary_sd);
-				dis_destroy_chan(svr_conns[index_to_shards]->secondary_sd);
-				svr_conns[index_to_shards]->secondary_sd = -1;
+				CS_close_socket(svr_conns[svr_index].secondary_sd);
+				CLOSESOCKET(svr_conns[svr_index].secondary_sd);
+				dis_destroy_chan(svr_conns[svr_index].secondary_sd);
+				svr_conns[svr_index].secondary_sd = -1;
 			}
 		}
-		svr_conns[index_to_shards]->state = SVR_CONN_STATE_DOWN;
-		pbs_client_thread_unlock_connection(entry_to_svr_conns);
+		svr_conns[svr_index].state = SVR_CONN_STATE_DOWN;
 	}
 }
 
@@ -473,7 +464,7 @@ restart(int sig)
 		pbs_loadconf(1);
 		log_open(logfile, path_log);
 
-		num_conf_svrs = get_current_servers();
+		num_conf_svrs = get_num_servers();
 
 		if (num_conf_svrs > MAX_ALLOWED_SVRS) {
 			log_record(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO, __func__,  "Maximum allowed servers exceeded");	
@@ -481,8 +472,8 @@ restart(int sig)
 		}
 
 		for (i = 0; i < num_conf_svrs; i++) {
-			if (pbs_conf.psi[i]->name != NULL)
-				addclient(pbs_conf.psi[i]->name);
+			if (pbs_conf.psi[i].name != NULL)
+				addclient(pbs_conf.psi[i].name);
 		}
 		
 		sprintf(log_buffer, "restart on signal %d", sig);
@@ -594,11 +585,10 @@ badconn(char *msg)
 int
 accept_svr_conn(int *max_sd)
 {
-	int		new_socket = -1;
-	pbs_socklen_t	slen;
-	int		i;
-	pbs_net_t	addr;
-	static int	svr_conns_initialised = 0;
+	int new_socket = -1;
+	pbs_socklen_t slen;
+	int i;
+	pbs_net_t addr;
 #ifdef TCP_USER_TIMEOUT
 	int 		tcp_timeout = TCP_TIMEOUT;
 #endif
@@ -631,7 +621,7 @@ accept_svr_conn(int *max_sd)
 	}
 
 	addr = (pbs_net_t)saddr.sin_addr.s_addr;
-	for (i=0; i<numclients; i++) {
+	for (i = 0; i < numclients; i++) {
 		if (addr == okclients[i])
 			break;
 	}
@@ -639,15 +629,6 @@ accept_svr_conn(int *max_sd)
 		badconn("unauthorized host");
 		close(new_socket);
 		return SCH_ERROR;
-	}
-
-	if (!svr_conns_initialised) {
-		svr_conn_t **svr_conns;
-		if ((svr_conns = initialize_server_conns(get_current_servers())) == NULL)
-			return -1;
-		set_conn_servers(new_socket, svr_conns);
-		svr_conns_initialised = 1;
-		entry_to_svr_conns = new_socket;
 	}
 
 	if (socket_to_conn(new_socket, saddr) == -1) {
@@ -891,7 +872,7 @@ main(int argc, char *argv[])
 	if (pbs_loadconf(0) == 0)
 		return (1);
 
-	num_cfg_svrs = get_current_servers();
+	num_cfg_svrs = get_num_servers();
 
 	set_log_conf(pbs_conf.pbs_leaf_name, pbs_conf.pbs_mom_node_name,
 			pbs_conf.locallog, pbs_conf.syslogfac,
@@ -1184,10 +1165,9 @@ main(int argc, char *argv[])
 	if (pbs_conf.pbs_leaf_name)
 		addclient(pbs_conf.pbs_leaf_name);
 
-
 	for (svr_inst_idx = 0; svr_inst_idx < num_cfg_svrs; svr_inst_idx++) {
-		if (pbs_conf.psi[svr_inst_idx]->name != NULL)
-			addclient(pbs_conf.psi[svr_inst_idx]->name);
+		if (pbs_conf.psi[svr_inst_idx].name != NULL)
+			addclient(pbs_conf.psi[svr_inst_idx].name);
 	}
 
 	if (configfile) {
@@ -1413,7 +1393,7 @@ main(int argc, char *argv[])
 		}
 
 		/* destroy ch_shards table */
-		for (svr_inst_idx = 0; svr_inst_idx < get_current_servers(); svr_inst_idx++) {
+		for (svr_inst_idx = 0; svr_inst_idx < get_num_servers(); svr_inst_idx++) {
 			if (svr_conns[svr_inst_idx])
 				free(svr_conns[svr_inst_idx]);
 		}
@@ -1447,19 +1427,13 @@ main(int argc, char *argv[])
 static int
 socket_to_conn(int sock, struct sockaddr_in saddr_in)
 {
-	svr_conn_t **svr_conns;
 	struct hostent *phe;
 	char *svr_id;
 	int cmd;
-	char *colon_ptr;
 	int svr_conn_index;
-
-	/* Use server_sock as virtual socket to get connection objects for all servers */
-	svr_conns = (svr_conn_t **)get_conn_servers(entry_to_svr_conns);
-	if (svr_conns == NULL) {
-		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "Error in getting svr_conns table");
-		return -1;
-	}
+	char svrname[PBS_MAXHOSTNAME];
+	int port;
+	svr_conn_t *conn_arr = NULL;
 
 	if (get_sched_cmd(sock, &cmd, &svr_id) != 1) {
 		log_eventf(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
@@ -1467,52 +1441,42 @@ socket_to_conn(int sock, struct sockaddr_in saddr_in)
 		return -1;
 	}
 
-	colon_ptr = strchr(svr_id, ':') ;
-	if (colon_ptr == NULL) {
+	if (parse_pbs_name_port(svr_id, svrname, &port) != 0) {
 		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "malformed svr_id");
 		return -1;
-	}	
-	*colon_ptr = '\0';
-	svr_conn_index = get_svr_index(svr_id);
-	*colon_ptr = ':';
-	if (svr_conn_index == -1) {
+	}
+
+	svr_conn_index = get_svr_index(svrname);
+	if (svr_conn_index == -1 || svr_conn_index >= get_num_servers()) {
 		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "Unknown server");
 		return -1;
 	}
 
-	if (svr_conns[svr_conn_index] == NULL) {
-		svr_conns[svr_conn_index] = malloc(sizeof(svr_conn_t));
-		if (svr_conns[svr_conn_index] == NULL) {
-			log_err(errno, __func__, MEM_ERR_MSG);
-			return -1;
-		}
-	
-		svr_conns[svr_conn_index]->sd = -1;
-		svr_conns[svr_conn_index]->secondary_sd = -1;
-	}
+	if ((conn_arr = get_conn_servers()) == NULL)
+		return -1;
 
-	if (svr_conns[svr_conn_index]->sd == -1) {
+	if (conn_arr[svr_conn_index].sd == -1) {
 		if ((phe = gethostbyaddr((char *) &saddr_in.sin_addr, sizeof(saddr_in.sin_addr), AF_INET)) == NULL) {
 			log_eventf(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
 				"gethostbyaddr failed, errno=%d in function %s ",  errno, __func__);
 			return -1;
 		}
 
-		strcpy(svr_conns[svr_conn_index]->host_name, phe->h_name);
+		strcpy(conn_arr[svr_conn_index].host_name, phe->h_name);
 		/* We will wait to mark this as connected until we get secondary connection */
-		svr_conns[svr_conn_index]->state = SVR_CONN_STATE_DOWN;
-		svr_conns[svr_conn_index]->state_change_time = time(0);
-		strcpy(svr_conns[svr_conn_index]->svr_id, svr_id);
+		conn_arr[svr_conn_index].state = SVR_CONN_STATE_DOWN;
+		conn_arr[svr_conn_index].state_change_time = time(0);
+		strcpy(conn_arr[svr_conn_index].svr_id, svr_id);
 	}
 
 	free(svr_id);
 
-	if (svr_conns[svr_conn_index]->sd == -1) {
-		svr_conns[svr_conn_index]->sd = sock;
+	if (conn_arr[svr_conn_index].sd == -1) {
+		conn_arr[svr_conn_index].sd = sock;
 		FD_SET(sock, &master_fdset);
 	} else {
-		svr_conns[svr_conn_index]->secondary_sd = sock;
-		svr_conns[svr_conn_index]->state = SVR_CONN_STATE_CONNECTED;
+		conn_arr[svr_conn_index].secondary_sd = sock;
+		conn_arr[svr_conn_index].state = SVR_CONN_STATE_CONNECTED;
 	}
 
 	return 0;
@@ -1572,19 +1536,21 @@ schedule_wrapper(fd_set *read_fdset, int opt_no_restart)
 	int cmd;
 	int alarm_time = 0;
 	char *runjobid = NULL;
-	svr_conn_t **svr_conns = NULL;
-	int num_cfg_svrs = get_current_servers();
+	svr_conn_t *svr_conns = NULL;
+	int num_cfg_svrs = get_num_servers();
 
-	/* Use virtual socket i.e. server_sock when calling get_conn_shards */
-	svr_conns = (svr_conn_t **)get_conn_servers(entry_to_svr_conns);
+	svr_conns = get_conn_servers();
 	if (svr_conns == NULL)
 		die(0);
 
-	for (svr_inst_idx = 0; svr_inst_idx < num_cfg_svrs; svr_inst_idx++) {
-		sock_to_check = svr_conns[svr_inst_idx]->sd;
-		second_connection = svr_conns[svr_inst_idx]->secondary_sd;
+	if (sigprocmask(SIG_BLOCK, &allsigs, &oldsigs) == -1)
+		log_err(errno, __func__, "sigprocmask(SIG_BLOCK)");
 
-		if ((sock_to_check != -1) && FD_ISSET(sock_to_check, read_fdset)) {
+	for (svr_inst_idx = 0; svr_inst_idx < num_cfg_svrs; svr_inst_idx++) {
+		sock_to_check = svr_conns[svr_inst_idx].sd;
+		second_connection = svr_conns[svr_inst_idx].secondary_sd;
+
+		if (sock_to_check != -1 && second_connection != -1 && FD_ISSET(sock_to_check, read_fdset)) {
 			int ret;
 			ret = get_sched_cmd(sock_to_check, &cmd, &runjobid);
 			if (ret != 1) {
@@ -1606,10 +1572,6 @@ schedule_wrapper(fd_set *read_fdset, int opt_no_restart)
 					num_svrs_updated++;
 				}
 
-
-				if (sigprocmask(SIG_BLOCK, &allsigs, &oldsigs) == -1)
-					log_err(errno, __func__, "sigprocmask(SIG_BLOCK)");
-
 				/* Keep track of time to use in SIGSEGV handler */
 #ifdef NAS /* localmod 031 */
 				now = time(NULL);
@@ -1627,20 +1589,17 @@ schedule_wrapper(fd_set *read_fdset, int opt_no_restart)
 				DBPRT(("Scheduler received command %d\n", cmd));
 #endif /* localmod 031 */
 
-				/* magic happens here */				
-				sched_ret = schedule(cmd, entry_to_svr_conns, runjobid);
-				if (sched_ret != 0 ) {
-					close_server_conn(svr_inst_idx);
-
+				/* magic happens here */
+				if ((sched_ret = schedule(cmd, sock_to_check, runjobid)) == 1) {
 					if (sigprocmask(SIG_SETMASK, &oldsigs, NULL) == -1)
 						log_err(errno, __func__, "sigprocmask(SIG_SETMASK)");
 
 					if (cmd == SCH_QUIT)
 						return 1;
-					else
-						continue;
-				} else {
-					if (send_cycle_end(second_connection))
+
+					close_server_conn(svr_inst_idx);
+				} else {	/* Successful cycle */
+					if (send_cycle_end(second_connection) == -1)
 						close_server_conn(svr_inst_idx);
 				}
 
@@ -1648,12 +1607,12 @@ schedule_wrapper(fd_set *read_fdset, int opt_no_restart)
 					free(runjobid);
 					runjobid = NULL;
 				}
-
-				if (sigprocmask(SIG_SETMASK, &oldsigs, NULL) == -1)
-					log_err(errno, __func__, "sigprocmask(SIG_SETMASK)");
 			}
 		}
 	}
+
+	if (sigprocmask(SIG_SETMASK, &oldsigs, NULL) == -1)
+		log_err(errno, __func__, "sigprocmask(SIG_SETMASK)");
 
 	return 0;
 }

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -196,6 +196,7 @@ new_resource_resv()
 	resresv->resresv_ind = -1;
 	resresv->run_event = NULL;
 	resresv->end_event = NULL;
+	resresv->svr_index = -1;
 
 	return resresv;
 }
@@ -702,6 +703,8 @@ dup_resource_resv(resource_resv *oresresv, server_info *nsinfo, queue_info *nqin
 		free_resource_resv(nresresv);
 		return NULL;
 	}
+
+	nresresv->svr_index = oresresv->svr_index;
 
 	return nresresv;
 }
@@ -1638,6 +1641,9 @@ update_resresv_on_run(resource_resv *resresv, nspec **nspec_arr)
 		resresv->start = resresv->server->server_time;
 		resresv->end = resresv->start + calc_time_left(resresv, 0);
 		resresv->job->accrue_type = JOB_RUNNING;
+
+		/* Job might have run on a different server, change it's owner */
+		resresv->svr_index = nspec_arr[0]->ninfo->svr_index;
 
 		if (resresv->aoename != NULL) {
 			for (i = 0; nspec_arr[i] != NULL; i++) {

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -69,6 +69,7 @@
 #include <pbs_ifl.h>
 #include <log.h>
 #include <libutil.h>
+#include <libpbs.h>
 
 #include "data_types.h"
 #include "resv_info.h"
@@ -1276,10 +1277,12 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 	int occr_count = nresv->resv->count;
 	int ridx = nresv->resv->resv_idx - 1;
 
+	svr_conn_t *svr_conn = get_conn_servers();
+
 	logmsg[0] = logmsg2[0] = '\0';
 
 	err = new_schd_error();
-	if (err == NULL)
+	if (err == NULL || svr_conn == NULL)
 		return RESV_CONFIRM_FAIL;
 
 
@@ -1554,6 +1557,9 @@ confirm_reservation(status *policy, int pbs_sd, resource_resv *unconf_resv, serv
 			rconf = RESV_CONFIRM_FAIL;
 		}
 	}
+
+	if (nresv_parent->svr_index != -1)
+		pbs_sd = svr_conn[nresv_parent->svr_index].sd;
 
 	/* Finished simulating occurrences now time to confirm if ok. Currently
 	 * the confirmation is an all or nothing process but may come to change. */

--- a/src/scheduler/server_info.h
+++ b/src/scheduler/server_info.h
@@ -474,6 +474,14 @@ node_info **dup_unordered_nodes(node_info **old_unordered_nodes, node_info **nno
 
 void *add_ptr_to_array(void *ptr_arr, void *ptr);
 
+svr_node_info *new_svr_node_info(void);
+svr_node_info **dup_svr_node_info_array(svr_node_info **old_arr, server_info *sinfo);
+svr_node_info *dup_svr_node_info(svr_node_info *old_obj, server_info *sinfo);
+
+void free_svr_node_info(svr_node_info *obj);
+
+void free_svr_node_info_array(svr_node_info **arr);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -97,12 +97,12 @@ extern int h_errno;
 
 
 /* Global Data */
-
-extern int	 svr_quehasnodes;
-extern int	 svr_totnodes;
-extern char	*path_nodes_new;
-extern char	*path_nodes;
-extern char	*path_nodestate;
+extern char *pbs_server_name;
+extern int svr_quehasnodes;
+extern int svr_totnodes;
+extern char *path_nodes_new;
+extern char *path_nodes;
+extern char *path_nodestate;
 extern pbs_list_head svr_queues;
 extern unsigned int pbs_mom_port;
 extern unsigned int pbs_rm_port;
@@ -351,7 +351,8 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 	pnode->nd_attr[(int)ND_ATR_Sharing].at_flags =
 		ATR_VFLAG_SET|ATR_VFLAG_DEFLT;
 
-	set_attr_svr(&(pnode->nd_attr[(int) ND_ATR_at_server]), &node_attr_def[(int) ND_ATR_at_server], pbs_conf.pbs_server_name);
+	/* Set the 'server' attribute on the node */
+	node_attr_def[ND_ATR_at_server].at_decode(&pnode->nd_attr[ND_ATR_at_server], NULL, NULL, pbs_server_name);
 
 	pat1 = &pnode->nd_attr[(int)ND_ATR_ResourceAvail];
 	pat2 = &pnode->nd_attr[(int)ND_ATR_ResourceAssn];

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -116,6 +116,7 @@ extern pbs_sched *sched_alloc(char *sched_name);
 extern void sched_free(pbs_sched *psched);
 extern int sched_delete(pbs_sched *psched);
 
+extern char *pbs_server_name;
 extern struct server server;
 extern pbs_list_head     svr_queues;
 extern attribute_def que_attr_def[];

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -288,13 +288,13 @@ call_to_process_hooks(struct batch_request *preq, char *hook_msg, size_t msg_len
 int
 need_to_run_elsewhere(struct batch_request *preq)
 {
-	char destination[PBS_MAX_SRV_INSTANCE + 1];
+	char destination[MAX_SVR_ID + 1];
 	char *pc;
 
 	if (!preq->rq_extend)
 		return FALSE;
 
-	strncpy(destination, preq->rq_extend, PBS_MAX_SRV_INSTANCE);
+	strncpy(destination, preq->rq_extend, sizeof(destination));
 	if ((pc = strchr(destination, ':')) != NULL)
 		*pc = '\0';
 	if (strcmp(destination, pbs_conf.pbs_server_name))

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -294,7 +294,7 @@ need_to_run_elsewhere(struct batch_request *preq)
 	if (!preq->rq_extend)
 		return FALSE;
 
-	strncpy(destination, preq->rq_extend, sizeof(destination));
+	strncpy(destination, preq->rq_extend, sizeof(destination) - 1);
 	if ((pc = strchr(destination, ':')) != NULL)
 		*pc = '\0';
 	if (strcmp(destination, pbs_conf.pbs_server_name))


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Enhancing scheduler to consider nodes from each server differently and schedule jobs giving preference to nodes from the server which owns it

#### Testing:
Setup: 2 servers, each with 1 node (4 ncpus) and an associated mom

- Submitted 5 jobs, 3 of them went to server "pbs", 2 of them went to server "pbs-2":
```
[ravi@pbs sched_logs]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
0.pbs             STDIN            ravi              00:00:00 R workq           
1.pbs             STDIN            ravi              00:00:00 R workq           
2.pbs             STDIN            ravi                     0 Q workq           
0.pbs-3           STDIN            ravi              00:00:00 R workq           
1.pbs-3           STDIN            ravi              00:00:00 R workq
```

- As seen above, the 5th job was queued because of lack of ncpus. Scheduler gave preference to the owner server for running the jobs:
```
[ravi@pbs sched_logs]$ pbsnodes -av
pbs
     Mom = pbs
     ntype = PBS
     state = free
     pcpus = 4
     jobs = 0.pbs/0, 1.pbs/1, 1.pbs/2
     resources_available.arch = linux
     resources_available.host = pbs
     resources_available.mem = 2038904kb
     resources_available.ncpus = 4
     resources_available.vnode = pbs
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 3
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     last_state_change_time = Tue Jul 14 04:27:34 2020

pbs-3
     Mom = pbs
     ntype = PBS
     state = free
     pcpus = 4
     jobs = 0.pbs-3/0, 1.pbs-3/1, 1.pbs-3/2
     resources_available.arch = linux
     resources_available.host = pbs
     resources_available.mem = 2038904kb
     resources_available.ncpus = 4
     resources_available.vnode = pbs-3
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 3
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     last_state_change_time = Tue Jul 14 04:28:14 2020
```

- When one of the jobs from pbs-2 finished, scheduler ran the job from server pbs on the node belonging to pbs-2 since the server pbs still didn't have any resources free:
```
[ravi@pbs sched_logs]$ qstat
Job id            Name             User              Time Use S Queue
----------------  ---------------- ----------------  -------- - -----
0.pbs             STDIN            ravi              00:00:00 R workq           
1.pbs             STDIN            ravi              00:00:00 R workq           
1.pbs-3           STDIN            ravi              00:00:00 R workq           
2.pbs             STDIN            ravi              00:00:00 R workq           
[ravi@pbs sched_logs]$ pbsnodes -av
pbs
     Mom = pbs
     ntype = PBS
     state = free
     pcpus = 4
     jobs = 0.pbs/0, 1.pbs/1, 1.pbs/2
     resources_available.arch = linux
     resources_available.host = pbs
     resources_available.mem = 2038904kb
     resources_available.ncpus = 4
     resources_available.vnode = pbs
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 3
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     last_state_change_time = Tue Jul 14 04:27:34 2020

pbs-3
     Mom = pbs
     ntype = PBS
     state = job-busy
     pcpus = 4
     jobs = 2.pbs/0, 1.pbs-3/1, 1.pbs-3/2, 2.pbs/3
     resources_available.arch = linux
     resources_available.host = pbs
     resources_available.mem = 2038904kb
     resources_available.ncpus = 4
     resources_available.vnode = pbs-3
     resources_assigned.accelerator_memory = 0kb
     resources_assigned.hbmem = 0kb
     resources_assigned.mem = 0kb
     resources_assigned.naccelerators = 0
     resources_assigned.ncpus = 4
     resources_assigned.vmem = 0kb
     resv_enable = True
     sharing = default_shared
     last_state_change_time = Tue Jul 14 04:36:02 2020
     last_used_time = Tue Jul 14 04:36:02 2020
```
