### PR TITLE
Scheduler run_job framework + Reload svr_conns during sched HUP + IFL…

### DIFF
--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -158,7 +158,6 @@ extern "C" {
 #define ATTR_state	"job_state"
 #define ATTR_queue	"queue"
 #define ATTR_server	"server"
-#define ATTR_pbs_server	"pbs_server"
 #define ATTR_maxrun	"max_running"
 #define ATTR_max_run		"max_run"
 #define ATTR_max_run_res	"max_run_res"

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -158,6 +158,7 @@ extern "C" {
 #define ATTR_state	"job_state"
 #define ATTR_queue	"queue"
 #define ATTR_server	"server"
+#define ATTR_pbs_server	"pbs_server"
 #define ATTR_maxrun	"max_running"
 #define ATTR_max_run		"max_run"
 #define ATTR_max_run_res	"max_run_res"

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -192,6 +192,8 @@ extern "C" {
 /* Default value of preempt_sort */
 #define PBS_PREEMPT_SORT_DEFAULT	"min_time_since_start"
 
+#define MAX_ALLOWED_SVRS 20
+
 /* Structure to store each server instance details */
 struct pbs_server_instance 
 {

--- a/src/include/pbs_internal.h
+++ b/src/include/pbs_internal.h
@@ -192,7 +192,7 @@ extern "C" {
 /* Default value of preempt_sort */
 #define PBS_PREEMPT_SORT_DEFAULT	"min_time_since_start"
 
-#define MAX_ALLOWED_SVRS 20
+#define MAX_ALLOWED_SVRS 100
 
 /* Structure to store each server instance details */
 struct pbs_server_instance 

--- a/src/lib/Libattr/master_node_attr_def.xml
+++ b/src/lib/Libattr/master_node_attr_def.xml
@@ -672,21 +672,21 @@
       </member_verify_function>
    </attributes>
    <attributes>
-   /* "ND_ATR_pbs_server" */
-	<member_name><both>ATTR_pbs_server</both></member_name>	<!-- "server" -->
-	<member_at_decode>decode_str</member_at_decode>
-	<member_at_encode>encode_str</member_at_encode>
-	<member_at_set>set_str</member_at_set>
-	<member_at_comp>comp_str</member_at_comp>
-	<member_at_free>free_str</member_at_free>
-	<member_at_action>NULL_FUNC</member_at_action>
-	<member_at_flags><both>READ_ONLY | ATR_DFLAG_SvWR</both></member_at_flags>
-	<member_at_type><both>ATR_TYPE_STR</both></member_at_type>
-	<member_at_parent>PARENT_TYPE_NODE</member_at_parent>
-	<member_verify_function>
-		<ECL>NULL_VERIFY_DATATYPE_FUNC</ECL>
-		<ECL>NULL_VERIFY_VALUE_FUNC</ECL>
-	</member_verify_function>
+      <member_index>ND_ATR_pbs_server</member_index>
+      <member_name>ATTR_pbs_server</member_name>
+      <member_at_decode>decode_str</member_at_decode>
+      <member_at_encode>encode_str</member_at_encode>
+      <member_at_set>set_str</member_at_set>
+      <member_at_comp>comp_str</member_at_comp>
+      <member_at_free>free_str</member_at_free>
+      <member_at_action>NULL_FUNC</member_at_action>
+      <member_at_flags>ATR_DFLAG_MGRD | ATR_DFLAG_MGWR</member_at_flags>
+      <member_at_type>ATR_TYPE_STR</member_at_type>
+      <member_at_parent>PARENT_TYPE_NODE</member_at_parent>
+      <member_verify_function>
+         <ECL>NULL_VERIFY_DATATYPE_FUNC</ECL>
+         <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+      </member_verify_function>
    </attributes>
    <tail>
    <SVR>};</SVR>

--- a/src/lib/Libattr/master_node_attr_def.xml
+++ b/src/lib/Libattr/master_node_attr_def.xml
@@ -671,6 +671,23 @@
          <ECL>NULL_VERIFY_VALUE_FUNC</ECL>
       </member_verify_function>
    </attributes>
+   <attributes>
+   /* "ND_ATR_pbs_server" */
+	<member_name><both>ATTR_pbs_server</both></member_name>	<!-- "server" -->
+	<member_at_decode>decode_str</member_at_decode>
+	<member_at_encode>encode_str</member_at_encode>
+	<member_at_set>set_str</member_at_set>
+	<member_at_comp>comp_str</member_at_comp>
+	<member_at_free>free_str</member_at_free>
+	<member_at_action>NULL_FUNC</member_at_action>
+	<member_at_flags><both>READ_ONLY | ATR_DFLAG_SvWR</both></member_at_flags>
+	<member_at_type><both>ATR_TYPE_STR</both></member_at_type>
+	<member_at_parent>PARENT_TYPE_NODE</member_at_parent>
+	<member_verify_function>
+		<ECL>NULL_VERIFY_DATATYPE_FUNC</ECL>
+		<ECL>NULL_VERIFY_VALUE_FUNC</ECL>
+	</member_verify_function>
+   </attributes>
    <tail>
    <SVR>};</SVR>
    <ECL>};

--- a/src/lib/Libattr/master_node_attr_def.xml
+++ b/src/lib/Libattr/master_node_attr_def.xml
@@ -672,8 +672,8 @@
       </member_verify_function>
    </attributes>
    <attributes>
-      <member_index>ND_ATR_pbs_server</member_index>
-      <member_name>ATTR_pbs_server</member_name>
+      <member_index>ND_ATR_at_server</member_index>
+      <member_name>ATTR_server</member_name>
       <member_at_decode>decode_str</member_at_decode>
       <member_at_encode>encode_str</member_at_encode>
       <member_at_set>set_str</member_at_set>

--- a/src/lib/Libifl/int_status.c
+++ b/src/lib/Libifl/int_status.c
@@ -129,7 +129,7 @@ PBSD_status_aggregate(int c, int cmd, char *id, struct attrl *attrib, char *exte
 
 	for (i = 0; i < get_current_servers(); i++) {
 		
-		if (svr_connections[i]->state != SVR_CONN_STATE_CONNECTED)
+		if ((svr_connections[i] == NULL) || svr_connections[i]->state != SVR_CONN_STATE_CONNECTED)
 			continue;
 
 		c = svr_connections[i]->sd;

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -414,7 +414,8 @@ initialize_server_conns(int num_conf_servers)
 {
 	int i;
 	int j;
-	svr_conn_t **svr_connections = calloc(num_conf_servers, sizeof(svr_conn_t *));
+	svr_conn_t **svr_connections = calloc(MAX_ALLOWED_SVRS, sizeof(svr_conn_t *));
+
 	if (!svr_connections)
 		return NULL;
 		

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -193,7 +193,7 @@ __pbs_selectjob(int c, struct attropl *attrib, char *extend)
 
 	for (i = 0; i < get_current_servers(); i++) {
 
-		if (svr_connections[i] && svr_connections[i]->state != SVR_CONN_STATE_CONNECTED)
+		if ((svr_connections[i] == NULL) || svr_connections[i]->state != SVR_CONN_STATE_CONNECTED)
 			continue;
 
 		c = svr_connections[i]->sd;
@@ -259,7 +259,7 @@ __pbs_selstat(int c, struct attropl *attrib, struct attrl *rattrib, char *extend
 
 	for (i = 0; i < get_current_servers(); i++) {
 
-		if (svr_connections[i]->state != SVR_CONN_STATE_CONNECTED)
+		if ((svr_connections[i] == NULL) || svr_connections[i]->state != SVR_CONN_STATE_CONNECTED)
 			continue;
 
 		c = svr_connections[i]->sd;

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2217,7 +2217,7 @@ random_srv_conn(svr_conn_t **svr_connections)
 	srand(time(0));
 	ind =  rand() % get_current_servers();
 
-	if ((svr_connections[ind] != NULL) && svr_connections[ind]->state == SVR_CONN_STATE_CONNECTED)
+	if (svr_connections[ind] && svr_connections[ind]->state == SVR_CONN_STATE_CONNECTED)
 		return svr_connections[ind]->sd;
 		
 	return get_available_conn(svr_connections);

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2194,9 +2194,12 @@ get_available_conn(svr_conn_t **svr_connections)
 {
 	int i;
 
-	for (i = 0; i < get_current_servers(); i++)
+	for (i = 0; i < get_current_servers(); i++) {
+		if (svr_connections[i] == NULL)
+			continue;
 		if (svr_connections[i]->state == SVR_CONN_STATE_CONNECTED)
 			return svr_connections[i]->sd;
+	}
 
 	return -1;
 }
@@ -2214,7 +2217,7 @@ random_srv_conn(svr_conn_t **svr_connections)
 	srand(time(0));
 	ind =  rand() % get_current_servers();
 
-	if (svr_connections[ind]->state == SVR_CONN_STATE_CONNECTED)
+	if ((svr_connections[ind] != NULL) && svr_connections[ind]->state == SVR_CONN_STATE_CONNECTED)
 		return svr_connections[ind]->sd;
 		
 	return get_available_conn(svr_connections);

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -611,6 +611,7 @@ struct job_info
 	resource_req *resreq_rel;	/* list of resources released */
 	char *depend_job_str;		/* dependent jobs in a ':' separated string */
 	resource_resv **dependent_jobs; /* dependent jobs with runone depenency */
+	char *pbs_server_name;
 
 #ifdef NAS
 	/* localmod 045 */
@@ -737,6 +738,7 @@ struct node_info
 	node_partition *hostset;	/* other vnodes on on the same host */
 	node_scratch nscr;		/* scratch space local to node search code */
 	char *partition;		/* partition to which node belongs to */
+	char *pbs_server_name;			/* svr_id which is of the form server_name:port */
 	time_t last_state_change_time;	/* Node state change at time stamp */
 	time_t last_used_time;		/* Node was last active at this time */
 	te_list *node_events;		/* list of run events that affect the node */

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -611,7 +611,7 @@ struct job_info
 	resource_req *resreq_rel;	/* list of resources released */
 	char *depend_job_str;		/* dependent jobs in a ':' separated string */
 	resource_resv **dependent_jobs; /* dependent jobs with runone depenency */
-	char *pbs_server_name;
+	char *svr_name;
 
 #ifdef NAS
 	/* localmod 045 */
@@ -738,7 +738,7 @@ struct node_info
 	node_partition *hostset;	/* other vnodes on on the same host */
 	node_scratch nscr;		/* scratch space local to node search code */
 	char *partition;		/* partition to which node belongs to */
-	char *pbs_server_name;			/* svr_id which is of the form server_name:port */
+	char *svr_name;			/* svr_id which is of the form server_name:port */
 	time_t last_state_change_time;	/* Node state change at time stamp */
 	time_t last_used_time;		/* Node was last active at this time */
 	te_list *node_events;		/* list of run events that affect the node */

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1312,52 +1312,50 @@ send_run_job(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode, char
 	char *extend = NULL;
 	int num_conf_svrs = get_current_servers();
 
-	/* if (num_conf_svrs > 1) { */
-		svr_conns = (svr_conn_t **)get_conn_servers(pbs_sd);
-		if (svr_conns == NULL) {
-			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "Error in getting svr_conns table");
+	svr_conns = (svr_conn_t **)get_conn_servers(pbs_sd);
+	if (svr_conns == NULL) {
+		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "Error in getting svr_conns table");
+		return -1;
+	}
+
+
+	for (i = 0; i < num_conf_svrs; i++) {
+		char *colon_ptr;
+
+		if (svr_conns[i] == NULL)
+			continue;
+
+		colon_ptr = strchr(svr_conns[i]->svr_id, ':') ;
+		if (colon_ptr == NULL) {
+			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "malformed svr_id");
 			return -1;
 		}
 
+		*colon_ptr = '\0';
 
-		for (i = 0; i < num_conf_svrs; i++) {
-			char *colon_ptr;
-
-			if (svr_conns[i] == NULL)
-				continue;
-
-			colon_ptr = strstr(svr_conns[i]->svr_id, ":") ;
-			if (colon_ptr == NULL) {
-				log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "malformed svr_id");
-				return -1;
-			}
-
-			*colon_ptr = '\0';
-
-			if (strcmp(svr_conns[i]->svr_id, svr_of_node) == 0) {
-				*colon_ptr = ':';
-				break;
-			}
-			
+		if (strcmp(svr_conns[i]->svr_id, svr_of_node) == 0) {
 			*colon_ptr = ':';
-			
+			break;
 		}
+		
+		*colon_ptr = ':';
+		
+	}
 
-		if (i == num_conf_svrs) {
-			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
-				"No matching for the source server to where the job is going to be sent");
-			return -1;
-		}
+	if (i == num_conf_svrs) {
+		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
+			"No matching for the source server to where the job is going to be sent");
+		return -1;
+	}
 
-		extend = svr_conns[i]->svr_id;
+	extend = svr_conns[i]->svr_id;
 
-		src_svr_index = get_svr_index(svr_of_job);
-		if (src_svr_index == -1) {
-			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
-				"No matching for the source server to where the job is going to be sent");	
-		}
-		pbs_sd = svr_conns[src_svr_index]->sd;
-	/* } */
+	src_svr_index = get_svr_index(svr_of_job);
+	if (src_svr_index == -1) {
+		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
+			"No matching for the source server to where the job is going to be sent");	
+	}
+	pbs_sd = svr_conns[src_svr_index]->sd;
 
 	if (sc_attrs.runjob_mode == RJ_EXECJOB_HOOK)
 		return pbs_runjob(pbs_sd, jobid, execvnode, extend);
@@ -1394,7 +1392,7 @@ run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, s
 	if (rjob == NULL || rjob->job == NULL || err == NULL)
 		return -1;
 
-	svr_of_job = rjob->job->pbs_server_name;
+	svr_of_job = rjob->job->svr_name;
 
 	/* Server most likely crashed */
 	if (got_sigpipe) {
@@ -1681,7 +1679,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 					fflush(stdout);
 #endif /* localmod 031 */
 
-					svr_of_node =  ns[0]->ninfo->pbs_server_name;
+					svr_of_node =  ns[0]->ninfo->svr_name;
 
 					pbsrc = run_job(pbs_sd, rr, execvnode, sinfo->has_runjob_hook, err, svr_of_node);
 

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -1306,6 +1306,7 @@ update_job_can_not_run(int pbs_sd, resource_resv *job, schd_error *err)
 static int
 send_run_job(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode, char *svr_of_node, char *svr_of_job)
 {
+	int src_svr_index;
 	svr_conn_t **svr_conns = NULL;
 	int i = 0;
 	char *extend = NULL;
@@ -1350,7 +1351,12 @@ send_run_job(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode, char
 
 		extend = svr_conns[i]->svr_id;
 
-		pbs_sd = svr_conns[i]->sd;
+		src_svr_index = get_svr_index(svr_of_job);
+		if (src_svr_index == -1) {
+			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
+				"No matching for the source server to where the job is going to be sent");	
+		}
+		pbs_sd = svr_conns[src_svr_index]->sd;
 	/* } */
 
 	if (sc_attrs.runjob_mode == RJ_EXECJOB_HOOK)

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -121,6 +121,7 @@
 #include "multi_threading.h"
 #include "pbs_python.h"
 #include "globals.h"
+#include "libpbs.h"
 
 #ifdef NAS
 #include "site_code.h"
@@ -1303,14 +1304,73 @@ update_job_can_not_run(int pbs_sd, resource_resv *job, schd_error *err)
  * @retval	return value of the runjob call
  */
 static int
-send_run_job(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode)
+send_run_job(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode, char *svr_of_node, char *svr_of_job)
 {
+	int svr_id_len = 0;
+	svr_conn_t **svr_conns = NULL;
+	int i = 0;
+	char *extend = NULL;
+	int num_conf_svrs = get_current_servers();
+
+	/* if (num_conf_svrs > 1) { */
+		svr_conns = (svr_conn_t **)get_conn_servers(pbs_sd);
+		if (svr_conns == NULL) {
+			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "Error in getting svr_conns table");
+			return -1;
+		}
+
+
+		for (i = 0; i < num_conf_svrs; i++) {
+			char *tmp_str;
+			char *colon_ptr;
+
+			if (svr_conns[i] == NULL)
+				continue;
+
+			tmp_str = string_dup(svr_conns[i]->svr_id);
+			if (tmp_str == NULL) {
+				log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "string_dup failure");
+				return -1;
+			}
+
+			colon_ptr = strstr(tmp_str, ":") ;
+			if (colon_ptr == NULL) {
+				log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "malformed svr_id");
+				return -1;
+			}
+
+			*colon_ptr = '\0';
+
+			if (strcmp(tmp_str, svr_of_node) == 0)
+				break;
+
+			free(tmp_str);
+		}
+
+		if (i == num_conf_svrs) {
+			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
+				"No matching for the source server to where the job is going to be sent");
+			return -1;
+		}
+
+		extend = malloc(MAX_SVR_ID);
+		if (extend == NULL) {
+			log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "malloc failure");
+			return -1;
+		}
+
+		svr_id_len = strlen(svr_conns[i]->svr_id);
+		extend[svr_id_len] = '\0';
+		strncpy(extend, svr_conns[i]->svr_id, svr_id_len);
+		pbs_sd = svr_conns[i]->sd;
+	/* } */
+
 	if (sc_attrs.runjob_mode == RJ_EXECJOB_HOOK)
-		return pbs_runjob(pbs_sd, jobid, execvnode, NULL);
+		return pbs_runjob(pbs_sd, jobid, execvnode, extend);
 	else if ((sc_attrs.runjob_mode == RJ_RUNJOB_HOOK) && has_runjob_hook)
-		return pbs_asyrunjob_ack(pbs_sd, jobid, execvnode, NULL);
+		return pbs_asyrunjob_ack(pbs_sd, jobid, execvnode, extend);
 	else
-		return pbs_asyrunjob(pbs_sd, jobid, execvnode, NULL);
+		return pbs_asyrunjob(pbs_sd, jobid, execvnode, extend);
 }
 
 /**
@@ -1330,14 +1390,17 @@ send_run_job(int pbs_sd, int has_runjob_hook, char *jobid, char *execvnode)
  * @retval -1	: error
  */
 int
-run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, schd_error *err)
+run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, schd_error *err, char *svr_of_node)
 {
 	char buf[100];	/* used to assemble queue@localserver */
 	char *errbuf;		/* comes from pbs_geterrmsg() */
 	int rc = 0;
+	char *svr_of_job;
 
 	if (rjob == NULL || rjob->job == NULL || err == NULL)
 		return -1;
+
+	svr_of_job = rjob->job->pbs_server_name;
 
 	/* Server most likely crashed */
 	if (got_sigpipe) {
@@ -1383,10 +1446,10 @@ run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, s
 				if (strlen(timebuf) > 0)
 					log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_JOB, LOG_NOTICE, rjob->name,
 						"Job will run for duration=%s", timebuf);
-				rc = send_run_job(pbs_sd, has_runjob_hook, rjob->name, execvnode);
+				rc = send_run_job(pbs_sd, has_runjob_hook, rjob->name, execvnode, svr_of_node, svr_of_job);
 			}
 		} else
-			rc = send_run_job(pbs_sd, has_runjob_hook, rjob->name, execvnode);
+			rc = send_run_job(pbs_sd, has_runjob_hook, rjob->name, execvnode,  svr_of_node, svr_of_job);
 	}
 
 	if (rc) {
@@ -1487,6 +1550,7 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 	resource_resv *rr;
 	char *err_txt = NULL;
 	char old_state = 0;
+	char *svr_of_node;
 
 	if (resresv == NULL || sinfo == NULL)
 		ret = -1;
@@ -1623,7 +1687,9 @@ run_update_resresv(status *policy, int pbs_sd, server_info *sinfo,
 					fflush(stdout);
 #endif /* localmod 031 */
 
-					pbsrc = run_job(pbs_sd, rr, execvnode, sinfo->has_runjob_hook, err);
+					svr_of_node =  ns[0]->ninfo->pbs_server_name;
+
+					pbsrc = run_job(pbs_sd, rr, execvnode, sinfo->has_runjob_hook, err, svr_of_node);
 
 #ifdef NAS_CLUSTER /* localmod 125 */
 					ret = translate_runjob_return_code(pbsrc, resresv);
@@ -2296,7 +2362,7 @@ next_job(status *policy, server_info *sinfo, int flag)
 	int queues_finished = 0;
 	int queue_index_size = 0;
 	int j = 0;
-	int ind;
+	int ind = -1;
 
 	if ((policy == NULL) || (sinfo == NULL))
 		return NULL;

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -180,8 +180,7 @@ int add_job_to_calendar(int pbs_sd, status *policy, server_info *sinfo, resource
  *	       first move it to the local server and then run it.
  *	       if it's a local job, just run it.
  */
-int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int had_runjob_hook, schd_error *err);
-
+int run_job(int pbs_sd, resource_resv *rjob, char *execvnode, int has_runjob_hook, schd_error *err, char *svr_of_node);
 /*
  *	should_backfill_with_job - should we call add_job_to_calendar() with job
  *	returns 1: we should backfill 0: we should not

--- a/src/scheduler/globals.c
+++ b/src/scheduler/globals.c
@@ -190,5 +190,3 @@ struct schedattrs sc_attrs;
 time_t last_attr_updates = 0;
 
 int send_job_attr_updates = 1;
-
-int svr_conn_index = 0;

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -108,8 +108,6 @@ extern time_t last_attr_updates;    /* timestamp of the last time attr updates w
 
 extern int send_job_attr_updates;
 
-extern int svr_conn_index;
-
 /**
  * @brief
  * It is used as a placeholder to store aoe name. This aoe name will be

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -1248,7 +1248,7 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 			resresv->job->job_name = string_dup(attrp->value);
 
 		else if (!strcmp(attrp->name, ATTR_server))
-			resresv->job->pbs_server_name = string_dup(attrp->value);
+			resresv->job->svr_name = string_dup(attrp->value);
 
 		else if (!strcmp(attrp->name, ATTR_state)) { /* state of job */
 			if (set_job_state(attrp->value, resresv->job) == 0) {
@@ -1483,7 +1483,7 @@ new_job_info()
 	jinfo->resreq_rel = NULL;
 	jinfo->depend_job_str = NULL;
 	jinfo->dependent_jobs = NULL;
-	jinfo->pbs_server_name = NULL;
+	jinfo->svr_name = NULL;
 
 
 	jinfo->formula_value = 0.0;
@@ -1547,8 +1547,8 @@ free_job_info(job_info *jinfo)
 	if (jinfo->dependent_jobs != NULL)
 		free(jinfo->dependent_jobs);
 
-	if (jinfo->pbs_server_name != NULL)
-		free(jinfo->pbs_server_name);
+	if (jinfo->svr_name != NULL)
+		free(jinfo->svr_name);
 
 	free_resource_req_list(jinfo->resused);
 
@@ -2861,7 +2861,7 @@ dup_job_info(job_info *ojinfo, queue_info *nqinfo, server_info *nsinfo)
 
 	njinfo->depend_job_str = string_dup(njinfo->depend_job_str);
 
-	njinfo->pbs_server_name = string_dup(ojinfo->pbs_server_name);
+	njinfo->svr_name = string_dup(ojinfo->svr_name);
 
 #ifdef RESC_SPEC
 	njinfo->rspec = dup_rescspec(ojinfo->rspec);

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -973,6 +973,7 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 			ATTR_c,
 			ATTR_r,
 			ATTR_depend,
+			ATTR_server,
 			NULL
 	};
 
@@ -1245,6 +1246,10 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 		}
 		else if (!strcmp(attrp->name, ATTR_N))		/* job name (qsub -N) */
 			resresv->job->job_name = string_dup(attrp->value);
+
+		else if (!strcmp(attrp->name, ATTR_server))
+			resresv->job->pbs_server_name = string_dup(attrp->value);
+
 		else if (!strcmp(attrp->name, ATTR_state)) { /* state of job */
 			if (set_job_state(attrp->value, resresv->job) == 0) {
 				set_schd_error_codes(err, NEVER_RUN, ERR_SPECIAL);
@@ -1478,6 +1483,7 @@ new_job_info()
 	jinfo->resreq_rel = NULL;
 	jinfo->depend_job_str = NULL;
 	jinfo->dependent_jobs = NULL;
+	jinfo->pbs_server_name = NULL;
 
 
 	jinfo->formula_value = 0.0;
@@ -1540,6 +1546,9 @@ free_job_info(job_info *jinfo)
 
 	if (jinfo->dependent_jobs != NULL)
 		free(jinfo->dependent_jobs);
+
+	if (jinfo->pbs_server_name != NULL)
+		free(jinfo->pbs_server_name);
 
 	free_resource_req_list(jinfo->resused);
 
@@ -2851,6 +2860,8 @@ dup_job_info(job_info *ojinfo, queue_info *nqinfo, server_info *nsinfo)
 		njinfo->ginfo = NULL;
 
 	njinfo->depend_job_str = string_dup(njinfo->depend_job_str);
+
+	njinfo->pbs_server_name = string_dup(ojinfo->pbs_server_name);
 
 #ifdef RESC_SPEC
 	njinfo->rspec = dup_rescspec(ojinfo->rspec);

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -1629,3 +1629,28 @@ free_ptr_array(void *inp)
 		free(arr[i]);
 	free(arr);
 }
+
+/**
+ * @brief	Set the server index value for the svr name
+ *
+ * @param[in]	svrname - name of the server
+ *
+ * @return int
+ * @retval server index
+ * @retval -1 for failure
+ */
+int
+get_svr_index(char *svrname)
+{
+	int i;
+	int svrindex = -1;
+
+	for (i = 0; i < pbs_conf.pbs_current_servers; i++) {
+		if (strcmp(pbs_conf.psi[i]->name, svrname) == 0) {
+			svrindex = i;
+			break;
+		}
+	}
+
+	return svrindex;
+}

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -289,6 +289,8 @@ add_str_to_unique_array(char ***str_arr, char *str);
  */
 void free_ptr_array (void *inp);
 
+int get_svr_index(char *svrname);
+
 #ifdef	__cplusplus
 }
 #endif

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -319,6 +319,7 @@ query_nodes(int pbs_sd, server_info *sinfo)
 			ATTR_NODE_last_state_change_time,
 			ATTR_NODE_last_used_time,
 			ATTR_NODE_resvs,
+			ATTR_pbs_server,
 			NULL
 	};
 
@@ -522,6 +523,15 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 				return NULL;
 			}
 		}
+
+		else if(!strcmp(attrp->name, ATTR_pbs_server)) {
+			ninfo->pbs_server_name = string_dup(attrp->value);
+			if (ninfo->pbs_server_name == NULL) {
+				log_err(errno, __func__, MEM_ERR_MSG);
+				return NULL;
+			}
+		}
+
 		else if (!strcmp(attrp->name, ATTR_NODE_jobs))
 			ninfo->jobs = break_comma_list(attrp->value);
 
@@ -767,6 +777,7 @@ new_node_info()
 #endif
 	new->partition = NULL;
 	new->np_arr = NULL;
+	new->pbs_server_name = NULL;
 	return new;
 }
 
@@ -954,6 +965,9 @@ free_node_info(node_info *ninfo)
 
 		if (ninfo->partition != NULL)
 			free(ninfo->partition);
+
+		if (ninfo->pbs_server_name != NULL)
+			free(ninfo->pbs_server_name);
 
 		if (ninfo->np_arr != NULL)
 			free(ninfo->np_arr);
@@ -1666,6 +1680,7 @@ dup_node_info(node_info *onode, server_info *nsinfo,
 
 	nnode->server = nsinfo;
 	nnode->name = string_dup(onode->name);
+	nnode->pbs_server_name = string_dup(onode->pbs_server_name);
 	nnode->mom = string_dup(onode->mom);
 	nnode->queue_name = string_dup(onode->queue_name);
 

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -319,7 +319,7 @@ query_nodes(int pbs_sd, server_info *sinfo)
 			ATTR_NODE_last_state_change_time,
 			ATTR_NODE_last_used_time,
 			ATTR_NODE_resvs,
-			ATTR_pbs_server,
+			ATTR_server,
 			NULL
 	};
 
@@ -524,9 +524,9 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 			}
 		}
 
-		else if(!strcmp(attrp->name, ATTR_pbs_server)) {
-			ninfo->pbs_server_name = string_dup(attrp->value);
-			if (ninfo->pbs_server_name == NULL) {
+		else if(!strcmp(attrp->name, ATTR_server)) {
+			ninfo->svr_name = string_dup(attrp->value);
+			if (ninfo->svr_name == NULL) {
 				log_err(errno, __func__, MEM_ERR_MSG);
 				return NULL;
 			}
@@ -777,7 +777,7 @@ new_node_info()
 #endif
 	new->partition = NULL;
 	new->np_arr = NULL;
-	new->pbs_server_name = NULL;
+	new->svr_name = NULL;
 	return new;
 }
 
@@ -966,8 +966,8 @@ free_node_info(node_info *ninfo)
 		if (ninfo->partition != NULL)
 			free(ninfo->partition);
 
-		if (ninfo->pbs_server_name != NULL)
-			free(ninfo->pbs_server_name);
+		if (ninfo->svr_name != NULL)
+			free(ninfo->svr_name);
 
 		if (ninfo->np_arr != NULL)
 			free(ninfo->np_arr);
@@ -1680,7 +1680,7 @@ dup_node_info(node_info *onode, server_info *nsinfo,
 
 	nnode->server = nsinfo;
 	nnode->name = string_dup(onode->name);
-	nnode->pbs_server_name = string_dup(onode->pbs_server_name);
+	nnode->svr_name = string_dup(onode->svr_name);
 	nnode->mom = string_dup(onode->mom);
 	nnode->queue_name = string_dup(onode->queue_name);
 

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -333,7 +333,6 @@ close_server_conn(int index_to_shards)
 			svr_conns[index_to_shards]->sd = -1;
 		}
 		svr_conns[index_to_shards]->state = SVR_CONN_STATE_DOWN;
-		svr_conn_index--;
 		pbs_client_thread_unlock_connection(entry_to_svr_conns);
 	}
 }
@@ -1447,49 +1446,68 @@ socket_to_conn(int sock, struct sockaddr_in saddr_in)
 {
 	svr_conn_t **svr_conns;
 	struct hostent *phe;
-	char *id;
+	char *svr_id;
 	int cmd;
-
-	if (svr_conn_index +1  > get_current_servers()) {
-		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
-			"Wrong PBS_SERVER_INSTANCES configuration");
-		return -1;
-	}
+	char *colon_ptr;
+	int svr_conn_index;
 
 	/* Use server_sock as virtual socket to get connection objects for all servers */
 	svr_conns = (svr_conn_t **)get_conn_servers(entry_to_svr_conns);
-	if (svr_conns == NULL)
+	if (svr_conns == NULL) {
+		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "Error in getting svr_conns table");
 		return -1;
+	}
 
-	if ((phe = gethostbyaddr((char *) &saddr_in.sin_addr, sizeof(saddr_in.sin_addr), AF_INET)) == NULL)
+	if (get_sched_cmd(sock, &cmd, &svr_id) != 1) {
+		log_eventf(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
+			"get_sched_cmd failed, errno=%d in function %s", errno, __func__);
 		return -1;
+	}
 
-
-	if (get_sched_cmd(sock, &cmd, &id) != 1)
+	colon_ptr = strstr(svr_id, ":") ;
+	if (colon_ptr == NULL) {
+		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "malformed svr_id");
 		return -1;
+	}	
+	*colon_ptr = '\0';
+	svr_conn_index = get_svr_index(svr_id);
+	*colon_ptr = ':';
+	if (svr_conn_index == -1) {
+		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "Unknown server");
+		return -1;
+	}
 
 	if (svr_conns[svr_conn_index] == NULL) {
 		svr_conns[svr_conn_index] = malloc(sizeof(svr_conn_t));
-		if (svr_conns[svr_conn_index] == NULL)
+		if (svr_conns[svr_conn_index] == NULL) {
+			log_err(errno, __func__, MEM_ERR_MSG);
 			return -1;
+		}
 	
 		svr_conns[svr_conn_index]->sd = -1;
 		svr_conns[svr_conn_index]->secondary_sd = -1;
-		svr_conns[svr_conn_index]->state = SVR_CONN_STATE_DOWN;	
 	}
-	strcpy(svr_conns[svr_conn_index]->host_name, phe->h_name);
-	svr_conns[svr_conn_index]->state = SVR_CONN_STATE_CONNECTED;
-	svr_conns[svr_conn_index]->state_change_time = time(0);
-	strcpy(svr_conns[svr_conn_index]->svr_id, id);
-	free(id);
+
+	if (svr_conns[svr_conn_index]->sd == -1) {
+		if ((phe = gethostbyaddr((char *) &saddr_in.sin_addr, sizeof(saddr_in.sin_addr), AF_INET)) == NULL) {
+			log_eventf(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
+				"gethostbyaddr failed, errno=%d in function %s ",  errno, __func__);
+			return -1;
+		}
+
+		strcpy(svr_conns[svr_conn_index]->host_name, phe->h_name);
+		svr_conns[svr_conn_index]->state = SVR_CONN_STATE_CONNECTED;
+		svr_conns[svr_conn_index]->state_change_time = time(0);
+		strcpy(svr_conns[svr_conn_index]->svr_id, svr_id);
+	}
+
+	free(svr_id);
 
 	if (svr_conns[svr_conn_index]->sd == -1) {
 		svr_conns[svr_conn_index]->sd = sock;
 		FD_SET(sock, &master_fdset);
-	} else {
+	} else
 		svr_conns[svr_conn_index]->secondary_sd = sock;
-		svr_conn_index++;
-	}
 
 	return 0;
 }
@@ -1577,6 +1595,7 @@ schedule_wrapper(int num_cfg_svrs, int *update_svr,fd_set *read_fdset, int opt_n
 				if (update_svr != NULL && (*update_svr)) {
 					/* update sched object attributes on server */
 					if (update_svr_schedobj(svr_conns[0]->sd, cmd, alarm_time) == 0) {
+						send_cycle_end(second_connection);
 						close_server_conn(svr_inst_idx);
 						continue;
 					}
@@ -1607,6 +1626,7 @@ schedule_wrapper(int num_cfg_svrs, int *update_svr,fd_set *read_fdset, int opt_n
 				/* magic happens here */				
 				sched_ret = schedule(cmd, svr_conns[0]->sd, runjobid);
 				if (sched_ret != 0 ) {
+					send_cycle_end(second_connection);
 					close_server_conn(svr_inst_idx);
 
 					if (sigprocmask(SIG_SETMASK, &oldsigs, NULL) == -1)

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -1464,7 +1464,7 @@ socket_to_conn(int sock, struct sockaddr_in saddr_in)
 		return -1;
 	}
 
-	colon_ptr = strstr(svr_id, ":") ;
+	colon_ptr = strchr(svr_id, ':') ;
 	if (colon_ptr == NULL) {
 		log_event(PBSEVENT_ERROR, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__, "malformed svr_id");
 		return -1;

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -342,11 +342,11 @@ free_prop_list(struct prop *prop)
 int
 initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 {
-	int	      i;
-	attribute    *pat1;
-	attribute    *pat2;
+	int i;
+	attribute *pat1;
+	attribute *pat2;
 	resource_def *prd;
-	resource     *presc;
+	resource *presc;
 
 	pnode->nd_name    = pname;
 	pnode->nd_ntype   = ntype;
@@ -398,6 +398,8 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 	pnode->nd_attr[(int)ND_ATR_Sharing].at_val.at_long = (long)VNS_DFLT_SHARED;
 	pnode->nd_attr[(int)ND_ATR_Sharing].at_flags =
 		ATR_VFLAG_SET|ATR_VFLAG_DEFLT;
+
+	set_attr_svr(&(pnode->nd_attr[(int) ND_ATR_pbs_server]), &node_attr_def[(int) ND_ATR_pbs_server], pbs_conf.pbs_server_name);
 
 	pat1 = &pnode->nd_attr[(int)ND_ATR_ResourceAvail];
 	pat2 = &pnode->nd_attr[(int)ND_ATR_ResourceAssn];

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -399,7 +399,7 @@ initialize_pbsnode(struct pbsnode *pnode, char *pname, int ntype)
 	pnode->nd_attr[(int)ND_ATR_Sharing].at_flags =
 		ATR_VFLAG_SET|ATR_VFLAG_DEFLT;
 
-	set_attr_svr(&(pnode->nd_attr[(int) ND_ATR_pbs_server]), &node_attr_def[(int) ND_ATR_pbs_server], pbs_conf.pbs_server_name);
+	set_attr_svr(&(pnode->nd_attr[(int) ND_ATR_at_server]), &node_attr_def[(int) ND_ATR_at_server], pbs_conf.pbs_server_name);
 
 	pat1 = &pnode->nd_attr[(int)ND_ATR_ResourceAvail];
 	pat2 = &pnode->nd_attr[(int)ND_ATR_ResourceAssn];

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -1423,8 +1423,8 @@ static int
 pbsd_init_job(job *pjob, int type)
 {
 	unsigned int d;
-	int	 newstate;
-	int	 newsubstate;
+	int newstate;
+	int newsubstate;
 
 	pjob->ji_momhandle = -1;
 	pjob->ji_mom_prot = PROT_INVALID;

--- a/src/server/sched_func.c
+++ b/src/server/sched_func.c
@@ -564,9 +564,7 @@ action_sched_port(attribute *pattr, void *pobj, int actmode)
 	psched = (pbs_sched *) pobj;
 
 	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
-		if ( dflt_scheduler && psched != dflt_scheduler) {
 			psched->pbs_scheduler_port = pattr->at_val.at_long;
-		}
 	}
 	return PBSE_NONE;
 }
@@ -591,11 +589,9 @@ action_sched_host(attribute *pattr, void *pobj, int actmode)
 	psched = (pbs_sched *) pobj;
 
 	if (actmode == ATR_ACTION_NEW || actmode == ATR_ACTION_ALTER || actmode == ATR_ACTION_RECOV) {
-		if ( dflt_scheduler && psched != dflt_scheduler) {
 			psched->pbs_scheduler_addr = get_hostaddr(pattr->at_val.at_str);
 			if (psched->pbs_scheduler_addr == (pbs_net_t)0)
 				return PBSE_BADATVAL;
-		}
 	}
 	return PBSE_NONE;
 }


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

This PR consists of the following changes.

- All the run_job related code changes which ensures that scheduler sends the jobs to the right server with the target server's hostname and port. Also need to make code changes ATTR_pbs_server/ATTR_server of Job and Node objects to have the respective pbs_server conf variable value. This includes both Server/Scheduler side changes.
- Fix for intermittent IFL call failures(especially before new server comes up fully if the IFL queries go to new server)
- Made Scheduler code changes **to reload svr_conns table** with the right data. After this I am able to test these changes by modifying PBS_SERVER_INSTANCES in pbs_conf without stopping PBS and verified that now sched reloads all svr_conns table.
- Even after the above changes pbs_add_server script started failing due to couple of race conditions when Server contacting scheduler. Find the root causes for the same and fixed it.
- Handling Misconfiguration at pbs_sched (for example more number of servers getting connected than configured)
-  **Making Server connect to remote Server :** Right now default scheduler does not connect to a different remote server in another complex. This was by design. Now I had to change it for Multi-Server so that two different PBS Complexes still can use single Scheduler. May be we need to rewrite some PTL test cases around this. We can take it up when we do it for mainline.
- Fixed a race condition in Scheduler Failover.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
I have tested the code changes by setting up multiple servers to the extent possible. Following are the logs for the same.
[MultiSvrTesting_v1.txt](https://github.com/subhasisb/openpbs/files/4888871/MultiSvrTesting_v1.txt)
 



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->