### PR TITLE
Code fix for stat issues when sched starts first in Mulit-Server environment

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -3013,7 +3013,7 @@ set_validate_sched_attrs(int connector)
 
 	/* Stat the scheduler to get details of sched */
 
-	all_ss = pbs_statsched(connector, NULL, NULL);
+	all_ss = pbs_statsched(entry_to_svr_conns, NULL, NULL);
 	ss = bs_find(all_ss, sc_name);
 
 	if (ss == NULL) {

--- a/src/scheduler/globals.c
+++ b/src/scheduler/globals.c
@@ -190,3 +190,5 @@ struct schedattrs sc_attrs;
 time_t last_attr_updates = 0;
 
 int send_job_attr_updates = 1;
+
+int entry_to_svr_conns;

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -108,6 +108,8 @@ extern time_t last_attr_updates;    /* timestamp of the last time attr updates w
 
 extern int send_job_attr_updates;
 
+extern int entry_to_svr_conns;
+
 /**
  * @brief
  * It is used as a placeholder to store aoe name. This aoe name will be

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -326,6 +326,10 @@ close_server_conn(int index_to_shards)
 			/* unlock the connection level lock */
 			svr_conns[index_to_shards]->sd = -1;
 			if (svr_conns[index_to_shards]->secondary_sd >= 0) {
+				/* We no need to call close_tcp_connection() once again on secondary connection
+				   It is because PBS_BATCH_Disconnect is sent as part of close_tcp_connection on primary.
+				   The other reason is Server is just expecting only end of cycle on secondary connection 
+				*/ 
 				CS_close_socket(svr_conns[index_to_shards]->secondary_sd);
 				CLOSESOCKET(svr_conns[index_to_shards]->secondary_sd);
 				dis_destroy_chan(svr_conns[index_to_shards]->secondary_sd);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
This PR addresses the following.

- Some of the stats failing from sched when it is started first before Server in Multi-Server environment
- Fix for race conditions in Scheduler's secondary connections.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

All the review and discussions happened in the following PR.
https://github.com/subhasisb/openpbs/pull/108

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
