### PR TITLE
Scheduling is not working when new servers added while scheduler is running

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2975,7 +2975,7 @@ set_validate_sched_attrs(int connector)
 
 	/* Stat the scheduler to get details of sched */
 
-	all_ss = pbs_statsched(entry_to_svr_conns, NULL, NULL);
+	all_ss = pbs_statsched(connector, NULL, NULL);
 	ss = bs_find(all_ss, sc_name);
 
 	if (ss == NULL) {

--- a/src/scheduler/globals.c
+++ b/src/scheduler/globals.c
@@ -191,4 +191,3 @@ time_t last_attr_updates = 0;
 
 int send_job_attr_updates = 1;
 
-int entry_to_svr_conns;

--- a/src/scheduler/globals.h
+++ b/src/scheduler/globals.h
@@ -108,7 +108,6 @@ extern time_t last_attr_updates;    /* timestamp of the last time attr updates w
 
 extern int send_job_attr_updates;
 
-extern int entry_to_svr_conns;
 
 /**
  * @brief


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

- When new servers in different PBS complex or in the same host are added while the Scheduler is running, Scheduling is not happening properly.

- pbs_statsched is failing which triggers Scheduler to not function properly

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
- When new servers in different PBS complex or in the same host are added while the Scheduler is running, Scheduling is not happening properly..
**Root cause:** While adding new servers either manually or through pbs_add_server script, pbs_conf is updated to have the new server details(hostname and port) to PBS_SERVER_INSTANCES which triggers SIGHUP upon which Scheduler reloads pbs_conf and sched_config. During this time we might need to update scheduler's connection array data structure to have a room for more servers and allocate memory and initialise accordingly  and also keep the previous data. This is not happening at present.

Added code changes to take care of this.

- pbs_statsched is failing which triggers Scheduler to not function properly
pbs_statsched from inside scheduler is failing because it is not called with proper socket descriptor. Added the code changes to take care of it.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
