### PR TITLE
Fix auth error in cluster created by pocker

### DIFF
--- a/src/cmds/scripts/pbs_pocker
+++ b/src/cmds/scripts/pbs_pocker
@@ -155,6 +155,7 @@ RUN set -ex \\
     && ../configure CFLAGS="-g -O2 -Wall -Werror" --prefix=/opt/pbs --enable-ptl --with-swig=/usr/local \\
     && make -j12 \\
     && make -j12 install \\
+    && chmod 4755 /opt/pbs/sbin/pbs_iff /opt/pbs/sbin/pbs_rcp \\
     && cd / \\
     && rm -rf /pbssrc
 __PP_DF__


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* client commands gives auth error when run as non-root user due to missing SUID bit on pbs_iff

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* added needed command to set SUID bit on pbs_iff and pbs_rcp after make install

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
