### PR TITLE
Should send all sched commands via secondary sock

### DIFF
--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1532,7 +1532,7 @@ try_db_again:
 			/* Bring up scheduler here */
 			pbs_scheduler_addr = get_hostaddr(pbs_conf.pbs_secondary);
 			dflt_scheduler->pbs_scheduler_addr = pbs_scheduler_addr;
-			if (contact_sched(SCH_SCHEDULE_NULL, NULL, dflt_scheduler, CONN_SCHED_PRIMARY) < 0) {
+			if (contact_sched(SCH_SCHEDULE_NULL, NULL, dflt_scheduler, CONN_SCHED_SECONDARY) < 0) {
 				char **workenv;
 				char schedcmd[MAXPATHLEN + 1];
 				/* save the current, "safe", environment.
@@ -1797,7 +1797,7 @@ try_db_again:
 	/* if brought up the Secondary Scheduler, take it down */
 
 	if (brought_up_alt_sched == 1)
-		(void)contact_sched(SCH_QUIT, NULL,  dflt_scheduler, CONN_SCHED_PRIMARY);
+		(void)contact_sched(SCH_QUIT, NULL,  dflt_scheduler, CONN_SCHED_SECONDARY);
 
 	/* if Moms are to to down as well, tell them */
 

--- a/src/server/req_shutdown.c
+++ b/src/server/req_shutdown.c
@@ -272,7 +272,7 @@ req_shutdown(struct batch_request *preq)
 		(void)failover_send_shutdown(FAILOVER_SecdShutdown);
 
 	if (shutdown_who & SHUT_WHO_SCHED)
-		(void)contact_sched(SCH_QUIT, NULL, dflt_scheduler, CONN_SCHED_PRIMARY);	/* tell scheduler to quit */
+		(void)contact_sched(SCH_QUIT, NULL, dflt_scheduler, CONN_SCHED_SECONDARY);	/* tell scheduler to quit */
 
 	if (shutdown_who & SHUT_WHO_SECDONLY) {
 		reply_ack(preq);

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -380,7 +380,7 @@ schedule_high(pbs_sched *psched)
 		return -1;
 
 	if (psched->sched_cycle_started == 0) {
-		if ((s = contact_sched(psched->svr_do_sched_high, NULL, psched, CONN_SCHED_PRIMARY)) < 0) {
+		if ((s = contact_sched(psched->svr_do_sched_high, NULL, psched, CONN_SCHED_SECONDARY)) < 0) {
 			set_sched_state(psched, SC_DOWN);
 			return -1;
 		}
@@ -449,7 +449,7 @@ schedule_jobs(pbs_sched *psched)
 			pdefr = (struct deferred_request *)GET_NEXT(pdefr->dr_link);
 		}
 
-		if ((s = contact_sched(cmd, jid,  psched, CONN_SCHED_PRIMARY)) < 0) {
+		if ((s = contact_sched(cmd, jid,  psched, CONN_SCHED_SECONDARY)) < 0) {
 			set_sched_state(psched, SC_DOWN);
 			return -1;
 		}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
This is hopefully the fix for stat issues. When we use the primary connection to communicate both the sched commands and the IFL replies, sometimes they can get mixed up. Here's an example:
server 1 triggers a sched cycle
server 2 also triggers a sched cycle, so the tcp buffers have a sched command to read for the scheduler
scheduler makes an IFL call to server 2 because of server 1's trigger
instead of a string reply, it gets an int sched command value from DIS, causing the issue

Kudos to Nithin for finding this issue.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Changing things so that ALL scheduler commands are now communicated via the secondary fd, leaving the primary fd for IFL. This will separate the IFL data from scheduler commands data.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
