### PR TITLE
Server sending sched commands on secondary + Bug fixes for few more race conditions

### DIFF
--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -834,7 +834,6 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 	time_t cur_time;		/* the current time via time() */
 	nspec **ns_arr = NULL;		/* node solution for job */
 	int i;
-	int cmd;
 	int sort_again = DONT_SORT_JOBS;
 	schd_error *err;
 	schd_error *chk_lim_err;
@@ -1093,7 +1092,8 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 				"Bailed out of main job loop after checking to see if %d jobs could run.", (i + 1));
 		}
 
-		if (!end_cycle) {
+/*TODO Need to handle super high priority commands when we move to mainline */
+/* 		if (!end_cycle) {
 			if (second_connection != -1) {
 				char *jid = NULL;
 
@@ -1106,7 +1106,7 @@ main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rerr)
 				if (jid != NULL)
 					free(jid);
 			}
-		}
+		} */
 
 #ifdef NAS /* localmod 030 */
 		if (check_for_cycle_interrupt(0)) {

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1695,7 +1695,8 @@ try_db_again:
 					/* cycle */
 					/* NOTE: both primary and secondary scheduler */
 					/* connect must have been setup to be valid */
-					if (psched->sched_cycle_started == 1) {
+					/*TODO Need to handle super high priority commands when we move to mainline */
+/* 					if (psched->sched_cycle_started == 1) {
 						if (put_sched_cmd(psched->scheduler_sock[1],
 								psched->svr_do_schedule, NULL) == 0) {
 							sprintf(log_buffer, "sent scheduler restart scheduling cycle request to %s", psched->sc_name);
@@ -1709,7 +1710,7 @@ try_db_again:
 						log_event(PBSEVENT_DEBUG3,
 							PBS_EVENTCLASS_SERVER,
 							LOG_NOTICE, msg_daemonname, log_buffer);
-					}
+					} */
 					psched->svr_do_schedule = SCH_SCHEDULE_NULL;
 				} else if (((svr_unsent_qrun_req) || ((psched->svr_do_schedule != SCH_SCHEDULE_NULL) &&
 					psched->sch_attr[(int)SCHED_ATR_scheduling].at_val.at_long))

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1532,7 +1532,7 @@ try_db_again:
 			/* Bring up scheduler here */
 			pbs_scheduler_addr = get_hostaddr(pbs_conf.pbs_secondary);
 			dflt_scheduler->pbs_scheduler_addr = pbs_scheduler_addr;
-			if (contact_sched(SCH_SCHEDULE_NULL, NULL, dflt_scheduler, CONN_SCHED_PRIMARY) < 0) {
+			if (contact_sched(SCH_SCHEDULE_NULL, NULL, dflt_scheduler, CONN_SCHED_SECONDARY) < 0) {
 				char **workenv;
 				char schedcmd[MAXPATHLEN + 1];
 				/* save the current, "safe", environment.
@@ -1797,7 +1797,7 @@ try_db_again:
 	/* if brought up the Secondary Scheduler, take it down */
 
 	if (brought_up_alt_sched == 1)
-		(void)contact_sched(SCH_QUIT, NULL,  dflt_scheduler, CONN_SCHED_PRIMARY);
+		(void)contact_sched(SCH_QUIT, NULL,  dflt_scheduler, CONN_SCHED_SECONDARY);
 
 	/* if Moms are to to down as well, tell them */
 

--- a/src/server/req_shutdown.c
+++ b/src/server/req_shutdown.c
@@ -272,7 +272,7 @@ req_shutdown(struct batch_request *preq)
 		(void)failover_send_shutdown(FAILOVER_SecdShutdown);
 
 	if (shutdown_who & SHUT_WHO_SCHED)
-		(void)contact_sched(SCH_QUIT, NULL, dflt_scheduler, CONN_SCHED_PRIMARY);	/* tell scheduler to quit */
+		(void)contact_sched(SCH_QUIT, NULL, dflt_scheduler, CONN_SCHED_SECONDARY);	/* tell scheduler to quit */
 
 	if (shutdown_who & SHUT_WHO_SECDONLY) {
 		reply_ack(preq);

--- a/src/server/run_sched.c
+++ b/src/server/run_sched.c
@@ -380,7 +380,7 @@ schedule_high(pbs_sched *psched)
 		return -1;
 
 	if (psched->sched_cycle_started == 0) {
-		if ((s = contact_sched(psched->svr_do_sched_high, NULL, psched, CONN_SCHED_PRIMARY)) < 0) {
+		if ((s = contact_sched(psched->svr_do_sched_high, NULL, psched, CONN_SCHED_SECONDARY)) < 0) {
 			set_sched_state(psched, SC_DOWN);
 			return -1;
 		}
@@ -449,7 +449,7 @@ schedule_jobs(pbs_sched *psched)
 			pdefr = (struct deferred_request *)GET_NEXT(pdefr->dr_link);
 		}
 
-		if ((s = contact_sched(cmd, jid,  psched, CONN_SCHED_PRIMARY)) < 0) {
+		if ((s = contact_sched(cmd, jid,  psched, CONN_SCHED_SECONDARY)) < 0) {
 			set_sched_state(psched, SC_DOWN);
 			return -1;
 		}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
This PR consists of the following changes 

- Changes needed to send sched commands on secondary connection. For more details please refer PR #118. 
- Added code changes for few more race conditions apart from the above and also fixed few more bugs like the below ones.
- Now that we are passing sched commands on secondary connection, necessary changes needed to close_server_conn() like clearing the secondary connection from fd_set.
- We should not directly assign -1 to server connections within sched code. If we do this, there is no notification sent to Server which can cause more problems. Removed this part of the code and made sure the scenario "Stop server, Bring it back while sched is running" works. Also tried various other things like restart complex1 when complex2 is up and vice versa etc.
- Cleaning up svr_conns memory properly
- Also made sure that Server and Scheduler should not have any code(commented it for now) changes relating to super high priority commands processing for now. This is needed because it can cause race conditions because super high priority commands are also sent on secondary connection. We actually have solutions for handling this case and do it while we move changes to mainline. These changes are not needed for POC. Added TODO in the code so that we will address it when we move to mainline.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Attached are test logs.
[SchedRaceConds.txt](https://github.com/subhasisb/openpbs/files/4993689/SchedRaceConds.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
