### PR TITLE
scheduler performance improvement for get_svr_index

### DIFF
--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -135,7 +135,6 @@ int get_conn_errno(int);
 pbs_tcp_chan_t * get_conn_chan(int);
 int set_conn_chan(int, pbs_tcp_chan_t *);
 pthread_mutex_t * get_conn_mutex(int);
-int get_svr_index_sock(int sock, svr_conn_t *svr_conns);
 extern int connect_to_servers(char *, uint, char *);
 /* max number of preempt orderings */
 #define PREEMPT_ORDER_MAX 20
@@ -339,13 +338,13 @@ extern int PBSD_status_put(int, int, char *, struct attrl *, char *, int, char *
 extern struct batch_reply *PBSD_rdrpy(int);
 extern struct batch_reply *PBSD_rdrpy_sock(int, int *);
 extern void PBSD_FreeReply(struct batch_reply *);
-extern struct batch_status *PBSD_status(int, int, char *, struct attrl *, char *);
+extern struct batch_status *PBSD_status(int, int, int, char *, struct attrl *, char *);
 extern int random_srv_conn(svr_conn_t *);
 extern int get_available_conn(svr_conn_t *svr_connections);
 extern struct batch_status *PBSD_status_aggregate(int, int, char *, struct attrl *, char *, int);
 extern struct batch_status *PBSD_status_random(int, int, char *, struct attrl *, char *, int);
 extern preempt_job_info *PBSD_preempt_jobs(int, char **);
-extern struct batch_status *PBSD_status_get(int, int);
+extern struct batch_status *PBSD_status_get(int, int, int);
 extern char *PBSD_queuejob(int, char *, char *, struct attropl *, char *, int, char **, int *);
 extern int decode_DIS_svrattrl(int, pbs_list_head *);
 extern int decode_DIS_attrl(int, struct attrl **);

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -135,6 +135,7 @@ int get_conn_errno(int);
 pbs_tcp_chan_t * get_conn_chan(int);
 int set_conn_chan(int, pbs_tcp_chan_t *);
 pthread_mutex_t * get_conn_mutex(int);
+int get_svr_index_sock(int sock, svr_conn_t *svr_conns);
 extern int connect_to_servers(char *, uint, char *);
 /* max number of preempt orderings */
 #define PREEMPT_ORDER_MAX 20
@@ -344,7 +345,7 @@ extern int get_available_conn(svr_conn_t *svr_connections);
 extern struct batch_status *PBSD_status_aggregate(int, int, char *, struct attrl *, char *, int);
 extern struct batch_status *PBSD_status_random(int, int, char *, struct attrl *, char *, int);
 extern preempt_job_info *PBSD_preempt_jobs(int, char **);
-extern struct batch_status *PBSD_status_get(int);
+extern struct batch_status *PBSD_status_get(int, int);
 extern char *PBSD_queuejob(int, char *, char *, struct attropl *, char *, int, char **, int *);
 extern int decode_DIS_svrattrl(int, pbs_list_head *);
 extern int decode_DIS_attrl(int, struct attrl **);

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -344,7 +344,7 @@ extern int get_available_conn(svr_conn_t *svr_connections);
 extern struct batch_status *PBSD_status_aggregate(int, int, char *, struct attrl *, char *, int);
 extern struct batch_status *PBSD_status_random(int, int, char *, struct attrl *, char *, int);
 extern preempt_job_info *PBSD_preempt_jobs(int, char **);
-extern struct batch_status *PBSD_status_get(int, int, int);
+extern struct batch_status *PBSD_status_get(int, int);
 extern char *PBSD_queuejob(int, char *, char *, struct attropl *, char *, int, char **, int *);
 extern int decode_DIS_svrattrl(int, pbs_list_head *);
 extern int decode_DIS_attrl(int, struct attrl **);

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -158,6 +158,7 @@ extern "C" {
 #define ATTR_state	"job_state"
 #define ATTR_queue	"queue"
 #define ATTR_server	"server"
+#define ATTR_server_index "server_index"
 #define ATTR_maxrun	"max_running"
 #define ATTR_max_run		"max_run"
 #define ATTR_max_run_res	"max_run_res"
@@ -574,7 +575,6 @@ typedef struct svr_conn {
 	int state;                  	/* Connection state */
 	time_t state_change_time;   	/* Connnetion state change time */
 	time_t last_used_time;      	/* Last used time for the connection */
-	char host_name[256];        	/* hostname of the connection coming from */
 	char svr_id[MAX_SVR_ID];    	/* svr_id of the form server_name:port */
 	char name[PBS_MAXHOSTNAME];	/* server name */
 	int port;						/* server port */

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -931,7 +931,6 @@ __pbs_disconnect(int connect)
 		for (i = 0; i < get_num_servers(); i++) {
 			if (svr_conns[i].sd == connect) {
 				svr_conns[i].sd = -1;
-				svr_conns[i].host_name[0] = '\0';
 				svr_conns[i].secondary_sd = -1;
 				svr_conns[i].state = SVR_CONN_STATE_DOWN;
 				svr_conns[i].state_change_time = time(NULL);

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -249,7 +249,7 @@ done:
 struct batch_status *
 __pbs_selstat(int c, struct attropl *attrib, struct attrl *rattrib, char *extend)
 {
-	extern struct batch_status *PBSD_status_get(int c);
+	extern struct batch_status *PBSD_status_get(int c, int type);
 	int i;
 	struct batch_status *ret = NULL;
 	struct batch_status *next = NULL;
@@ -282,7 +282,7 @@ __pbs_selstat(int c, struct attropl *attrib, struct attrl *rattrib, char *extend
 
 
 		if (PBSD_select_put(c, PBS_BATCH_SelStat, attrib, rattrib, extend) == 0) {
-			if ((next = PBSD_status_get(c))) {
+			if ((next = PBSD_status_get(c, PBS_BATCH_SelStat))) {
 				if (!ret) {
 					ret = next;
 					cur = next->last;

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -249,7 +249,7 @@ done:
 struct batch_status *
 __pbs_selstat(int c, struct attropl *attrib, struct attrl *rattrib, char *extend)
 {
-	extern struct batch_status *PBSD_status_get(int c, int svr_index, int type);
+	extern struct batch_status *PBSD_status_get(int c, int svr_index);
 	int i;
 	struct batch_status *ret = NULL;
 	struct batch_status *next = NULL;
@@ -282,7 +282,7 @@ __pbs_selstat(int c, struct attropl *attrib, struct attrl *rattrib, char *extend
 
 
 		if (PBSD_select_put(c, PBS_BATCH_SelStat, attrib, rattrib, extend) == 0) {
-			if ((next = PBSD_status_get(c, i, PBS_BATCH_SelStat))) {
+			if ((next = PBSD_status_get(c, i))) {
 				if (!ret) {
 					ret = next;
 					cur = next->last;

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -249,7 +249,7 @@ done:
 struct batch_status *
 __pbs_selstat(int c, struct attropl *attrib, struct attrl *rattrib, char *extend)
 {
-	extern struct batch_status *PBSD_status_get(int c, int type);
+	extern struct batch_status *PBSD_status_get(int c, int svr_index, int type);
 	int i;
 	struct batch_status *ret = NULL;
 	struct batch_status *next = NULL;
@@ -282,7 +282,7 @@ __pbs_selstat(int c, struct attropl *attrib, struct attrl *rattrib, char *extend
 
 
 		if (PBSD_select_put(c, PBS_BATCH_SelStat, attrib, rattrib, extend) == 0) {
-			if ((next = PBSD_status_get(c, PBS_BATCH_SelStat))) {
+			if ((next = PBSD_status_get(c, i, PBS_BATCH_SelStat))) {
 				if (!ret) {
 					ret = next;
 					cur = next->last;

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2268,3 +2268,25 @@ rand_num()
 
 	return rand();
 }
+
+/**
+ * @brief 	Used to get server index given socket descriptor
+ * @return int
+ * @retval server index
+ * @retval -1 for failure
+ */
+int
+get_svr_index_sock(int sock, svr_conn_t *svr_conns)
+{
+	int i;
+	int svrindex = -1;
+
+	for (i = 0; i < get_num_servers(); i++) {
+		if (svr_conns[i].sd == sock) {
+			svrindex = i;
+			break;
+		}
+	}
+
+	return svrindex;
+}

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2268,25 +2268,3 @@ rand_num()
 
 	return rand();
 }
-
-/**
- * @brief 	Used to get server index given socket descriptor
- * @return int
- * @retval server index
- * @retval -1 for failure
- */
-int
-get_svr_index_sock(int sock, svr_conn_t *svr_conns)
-{
-	int i;
-	int svrindex = -1;
-
-	for (i = 0; i < get_num_servers(); i++) {
-		if (svr_conns[i].sd == sock) {
-			svrindex = i;
-			break;
-		}
-	}
-
-	return svrindex;
-}

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -1217,8 +1217,12 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 			resresv->job->NAS_pri = resresv->job->priority;
 #endif /* localmod 045 */
 		}
-		else if (!strcmp(attrp->name, ATTR_server)) {
-			resresv->svr_index = get_svr_index(attrp->value);
+		else if (!strcmp(attrp->name, ATTR_server_index)) {
+			count = strtol(attrp->value, &endp, 10);
+			if (*endp == '\0')
+				resresv->svr_index = count;
+			else
+				resresv->svr_index = -1;
 			if (resresv->svr_index == -1) {
 				free_resource_resv(resresv);
 				return NULL;

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -624,8 +624,12 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 		if (!strcmp(attrp->name, ATTR_NODE_state))
 			set_node_info_state(ninfo, attrp->value);
 
-		else if (!strcmp(attrp->name, ATTR_server)) {
-			ninfo->svr_index = get_svr_index(attrp->value);
+		else if (!strcmp(attrp->name, ATTR_server_index)) {
+			count = strtol(attrp->value, &endp, 10);
+			if (*endp == '\0')
+				ninfo->svr_index = count;
+			else
+				ninfo->svr_index = -1;
 			if (ninfo->svr_index == -1) {
 				free_node_info(ninfo);
 				return NULL;

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -1445,7 +1445,6 @@ main(int argc, char *argv[])
 static int
 socket_to_conn(int sock, struct sockaddr_in saddr_in)
 {
-	struct hostent *phe;
 	char *svr_id;
 	int cmd;
 	int svr_conn_index;
@@ -1474,13 +1473,6 @@ socket_to_conn(int sock, struct sockaddr_in saddr_in)
 		return -1;
 
 	if (conn_arr[svr_conn_index].sd == -1) {
-		if ((phe = gethostbyaddr((char *) &saddr_in.sin_addr, sizeof(saddr_in.sin_addr), AF_INET)) == NULL) {
-			log_eventf(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SCHED, LOG_ERR, __func__,
-				"gethostbyaddr failed, errno=%d in function %s ",  errno, __func__);
-			return -1;
-		}
-
-		strcpy(conn_arr[svr_conn_index].host_name, phe->h_name);
 		/* We will wait to mark this as connected until we get secondary connection */
 		conn_arr[svr_conn_index].state = SVR_CONN_STATE_DOWN;
 		conn_arr[svr_conn_index].state_change_time = time(0);


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
As of now get_svr_index() is being used inside Scheduler code heavily especially under the following scenarios.

- For every job 
- For every node

This happens for every cycle when we query the data from Server/s. get_svr_index() loops through all svr_conns given a server name to find out the index associated with that server. Looping svr_conns array for every job and node is very costly and is O(n) time complexity where n is proportional to number of servers. The function also does a strcmp to match the server name with the given name which is again a costly operation. This enhancement is an attempt to not use get_svr_index() in the above situations and makes Scheduler to get server index in O(1) time in the above scenarios. 

In fact Scheduler now uses get_svr_index() only once when Server/s are connecting to Scheduler at the time of connection initiation which is required anyways.

Also removed some unneeded code from Scheduler as part of this work.

Just out of curiosity, I have run the following performance test in a performance machine before and after this enhancement. Following are the results.  Have selected this scenario purposefully just to increase load on Scheduler. 
Scenario: Make Scheduling off and Submit 50,000 jobs, then enable scheduling and measure the performance.


  | Servers | Moms | ncpus | Jobs | Sched   Throughput     in sec | End to end   throughput     in sec | jobs/sec
-- | -- | -- | -- | -- | -- | -- | --
Integration   branch | 10 | 200 | 250 | 50000 | 9.03 | 16 | 3125
PR branch | 10 | 200 | 250 | 50000 | 8.01 | 15 | 3333.333333
  |   |   |   |   |   | Increase in jobs/sec | 208.3333333

By looking at the above numbers it looks like it is definitely increasing performance. We can get better results if we increase the load on Scheduler heavily. 50,000 jobs also to Scheduler seems less to verify the said scenario. May be we can try with more servers and thousands of moms in which case the difference would be more substantial.


#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
