### PR TITLE
bug fixes

### DIFF
--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -307,8 +307,8 @@ void
 move_and_runjob(struct batch_request *preq, job *pjob)
 {
 	char *dest;
-	int sock;
-	int conn = -1;
+	//int sock;
+	//int conn = -1;
 	pbs_net_t	 hostaddr;
 	unsigned int	 port = pbs_server_port_dis;
 
@@ -322,7 +322,7 @@ move_and_runjob(struct batch_request *preq, job *pjob)
 
 	get_hostaddr_port_from_svr(preq->rq_ind.rq_move.rq_destin, &hostaddr, &port);
 
-	sock = get_peer_server_sock(hostaddr, port);
+	/*sock = get_peer_server_sock(hostaddr, port);
 	if (sock != -1 && !is_socket_up(sock)) {
 		log_eventf(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO,
 				__func__, "Error from peer server socket fd, "
@@ -341,7 +341,7 @@ move_and_runjob(struct batch_request *preq, job *pjob)
 			   __func__, "New Peer Server fd of server: %s is :%d",
 			   preq->rq_extend, conn);
 		set_peer_server_conn(conn);
-	}
+	}*/
 
 	req_movejob(preq);
 }

--- a/src/server/svr_connect.c
+++ b/src/server/svr_connect.c
@@ -135,8 +135,9 @@ svr_connect(pbs_net_t hostaddr, unsigned int port, void (*func)(int), enum conn_
 	if ((hostaddr == pbs_server_addr) && (port == pbs_server_port_dis))
 		return (PBS_LOCAL_CONNECTION);	/* special value for local */
 
-	if ((sock = get_peer_server_sock(hostaddr, port)) != -1)
+	/*if ((sock = get_peer_server_sock(hostaddr, port)) != -1)
 		return sock;
+	*/
 
 	pmom = tfind2((unsigned long)hostaddr, port, &ipaddrs);
 	if ((pmom != NULL) && (port == pmom->mi_port)) {
@@ -261,8 +262,9 @@ svr_disconnect_with_wait_option(int sock, int wait)
 	if (sock < 0 || sock >= PBS_LOCAL_CONNECTION)
 		return ;
 
-	if (get_peer_server_sock(get_connectaddr(sock), get_connectport(sock)) != -1)
+	/*if (get_peer_server_sock(get_connectaddr(sock), get_connectport(sock)) != -1)
 		return;
+	*/
 
 	if (pbs_client_thread_lock_connection(sock) != 0)
 		return;


### PR DESCRIPTION
* Failures in move + run path, job seems stuck in T state, Protocol error in server logs
Why? As multiple forked processes trying to read the reply from peer server using the same FD, they might be reading the wrong values.
Fix: Commenting out the code for reusing FD. This will be cleaned up when we make use of send_job_exec path.

* Resources Aggregation garbles values and qstat -Bf intermittent failures