### PR TITLE
Cherry-pick stat fix and svr shudown optimization from master

### DIFF
--- a/src/cmds/Makefile.am
+++ b/src/cmds/Makefile.am
@@ -105,7 +105,7 @@ common_sources = \
 
 pbsdsh_CPPFLAGS = ${common_cflags}
 pbsdsh_LDADD = ${common_libs}
-pbsdsh_SOURCES = pbsdsh.c
+pbsdsh_SOURCES = pbsdsh.c ${common_sources}
 
 pbsnodes_CPPFLAGS = ${common_cflags}
 pbsnodes_LDADD = ${common_libs}
@@ -132,7 +132,7 @@ pbs_ds_password_bin_SOURCES = pbs_ds_password.c ${common_sources}
 
 pbs_tmrsh_CPPFLAGS = ${common_cflags}
 pbs_tmrsh_LDADD = ${common_libs}
-pbs_tmrsh_SOURCES = pbs_tmrsh.c
+pbs_tmrsh_SOURCES = pbs_tmrsh.c ${common_sources}
 
 pbs_ralter_CPPFLAGS = ${common_cflags}
 pbs_ralter_LDADD = ${common_libs}

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -332,13 +332,13 @@ extern int PBSD_status_put(int, int, char *, struct attrl *, char *, int, char *
 extern struct batch_reply *PBSD_rdrpy(int);
 extern struct batch_reply *PBSD_rdrpy_sock(int, int *);
 extern void PBSD_FreeReply(struct batch_reply *);
-extern struct batch_status *PBSD_status(int, int, int, char *, struct attrl *, char *);
+extern struct batch_status *PBSD_status(int, int, char *, struct attrl *, char *);
 extern int random_srv_conn(svr_conn_t *);
 extern int get_available_conn(svr_conn_t *svr_connections);
 extern struct batch_status *PBSD_status_aggregate(int, int, char *, struct attrl *, char *, int);
 extern struct batch_status *PBSD_status_random(int, int, char *, struct attrl *, char *, int);
 extern preempt_job_info *PBSD_preempt_jobs(int, char **);
-extern struct batch_status *PBSD_status_get(int, int);
+extern struct batch_status *PBSD_status_get(int);
 extern char *PBSD_queuejob(int, char *, char *, struct attropl *, char *, int, char **, int *);
 extern int decode_DIS_svrattrl(int, pbs_list_head *);
 extern int decode_DIS_attrl(int, struct attrl **);

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -157,13 +157,6 @@ struct brp_status {
 	pbs_list_head brp_attr; /* head of svrattrlist */
 };
 
-struct brp_cmdstat {
-	struct brp_cmdstat *brp_stlink;
-	int brp_objtype;
-	char brp_objname[(PBS_MAXSVRJOBID > PBS_MAXDEST ? PBS_MAXSVRJOBID : PBS_MAXDEST) + 1];
-	struct attrl *brp_attrl;
-};
-
 /* reply to Resource Query Request */
 struct brp_rescq {
 	int brq_number; /* number of items in following arrays */
@@ -202,11 +195,12 @@ struct batch_reply
 	int brp_auxcode;
 	int brp_choice; /* the union discriminator */
 	int brp_is_part;
+	int brp_count;
 	union {
 		char brp_jid[PBS_MAXSVRJOBID + 1];
 		struct brp_select *brp_select; /* select replies */
 		pbs_list_head brp_status; /* status (svr) replies */
-		struct brp_cmdstat *brp_statc; /* status (cmd) replies) */
+		struct batch_status *brp_statc; /* status (cmd) replies) */
 		struct {
 			int brp_txtlen;
 			char *brp_str;

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -158,7 +158,6 @@ extern "C" {
 #define ATTR_state	"job_state"
 #define ATTR_queue	"queue"
 #define ATTR_server	"server"
-#define ATTR_server_index "server_index"
 #define ATTR_maxrun	"max_running"
 #define ATTR_max_run		"max_run"
 #define ATTR_max_run_res	"max_run_res"

--- a/src/lib/Libdis/dis_helpers.c
+++ b/src/lib/Libdis/dis_helpers.c
@@ -36,7 +36,7 @@
  * "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
  * subject to Altair's trademark licensing policies.
  */
-
+#include <pbs_config.h>
 #include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>

--- a/src/lib/Libifl/dec_attrl.c
+++ b/src/lib/Libifl/dec_attrl.c
@@ -118,11 +118,7 @@ decode_DIS_attrl(int sock, struct attrl **ppatt)
 		pat->value = disrst(sock, &rc);
 		if (rc) break;
 
-#ifdef NAS /* localmod 005 */
 		pat->op = (enum batch_op) disrui(sock, &rc);
-#else
-		pat->op = disrui(sock, &rc);
-#endif /* localmod 005 */
 		if (rc) break;
 
 		if (i == 0) {

--- a/src/lib/Libifl/dec_rpyc.c
+++ b/src/lib/Libifl/dec_rpyc.c
@@ -85,46 +85,53 @@
 int
 decode_DIS_replyCmd(int sock, struct batch_reply *reply)
 {
-	int		      ct;
-	int		      i;
-	struct brp_select    *psel;
-	struct brp_select   **pselx;
-	struct brp_cmdstat   *pstcmd;
-	struct brp_cmdstat  **pstcx = NULL;
-	int		      rc = 0;
-	size_t		      txtlen;
-	preempt_job_info 	*ppj = NULL;
+	int ct;
+	int i;
+	struct brp_select *psel;
+	struct brp_select **pselx;
+	struct batch_status *pstcmd;
+	struct batch_status **pstcx = NULL;
+	int rc = 0;
+	size_t txtlen;
+	preempt_job_info *ppj = NULL;
 
 	/* first decode "header" consisting of protocol type and version */
 again:
 	i = disrui(sock, &rc);
-	if (rc != 0) return rc;
-	if (i != PBS_BATCH_PROT_TYPE) return DIS_PROTO;
+	if (rc != 0)
+		return rc;
+	if (i != PBS_BATCH_PROT_TYPE)
+		return DIS_PROTO;
 	i = disrui(sock, &rc);
-	if (rc != 0) return rc;
-	if (i != PBS_BATCH_PROT_VER) return DIS_PROTO;
+	if (rc != 0)
+		return rc;
+	if (i != PBS_BATCH_PROT_VER)
+		return DIS_PROTO;
 
 	/* next decode code, auxcode and choice (union type identifier) */
 
-	reply->brp_code    = disrsi(sock, &rc);
-	if (rc) return rc;
+	reply->brp_code = disrsi(sock, &rc);
+	if (rc)
+		return rc;
 	reply->brp_auxcode = disrsi(sock, &rc);
-	if (rc) return rc;
-	reply->brp_choice  = disrui(sock, &rc);
-	if (rc) return rc;
-	reply->brp_is_part  = disrui(sock, &rc);
-	if (rc) return rc;
-
+	if (rc)
+		return rc;
+	reply->brp_choice = disrui(sock, &rc);
+	if (rc)
+		return rc;
+	reply->brp_is_part = disrui(sock, &rc);
+	if (rc)
+		return rc;
 
 	switch (reply->brp_choice) {
 
 		case BATCH_REPLY_CHOICE_NULL:
-			break;	/* no more to do */
+			break; /* no more to do */
 
 		case BATCH_REPLY_CHOICE_Queue:
 		case BATCH_REPLY_CHOICE_RdytoCom:
 		case BATCH_REPLY_CHOICE_Commit:
-			disrfst(sock, PBS_MAXSVRJOBID+1, reply->brp_un.brp_jid);
+			disrfst(sock, PBS_MAXSVRJOBID + 1, reply->brp_un.brp_jid);
 			if (rc)
 				return (rc);
 			break;
@@ -136,20 +143,23 @@ again:
 			reply->brp_un.brp_select = NULL;
 			pselx = &reply->brp_un.brp_select;
 			ct = disrui(sock, &rc);
-			if (rc) return rc;
+			if (rc)
+				return rc;
+			reply->brp_count = ct;
 
 			while (ct--) {
-				psel = (struct brp_select *)malloc(sizeof(struct brp_select));
-				if (psel == 0) return DIS_NOMALLOC;
+				psel = (struct brp_select *) malloc(sizeof(struct brp_select));
+				if (psel == 0)
+					return DIS_NOMALLOC;
 				psel->brp_next = NULL;
 				psel->brp_jobid[0] = '\0';
-				rc = disrfst(sock, PBS_MAXSVRJOBID+1, psel->brp_jobid);
+				rc = disrfst(sock, PBS_MAXSVRJOBID + 1, psel->brp_jobid);
 				if (rc) {
-					(void)free(psel);
+					(void) free(psel);
 					return rc;
 				}
 				*pselx = psel;
-				pselx  = &psel->brp_next;
+				pselx = &psel->brp_next;
 			}
 			break;
 
@@ -159,32 +169,35 @@ again:
 			if (pstcx == NULL) {
 				reply->brp_un.brp_statc = NULL;
 				pstcx = &reply->brp_un.brp_statc;
+				reply->brp_count = 0;
 			}
 			ct = disrui(sock, &rc);
-			if (rc) return rc;
+			if (rc)
+				return rc;
+			reply->brp_count += ct;
 
 			while (ct--) {
-				pstcmd = (struct brp_cmdstat *)malloc(sizeof(struct brp_cmdstat));
-				if (pstcmd == 0) return DIS_NOMALLOC;
+				pstcmd = (struct batch_status *) malloc(sizeof(struct batch_status));
+				if (pstcmd == 0)
+					return DIS_NOMALLOC;
+				pstcmd->next = NULL;
+				pstcmd->text = NULL;
+				pstcmd->attribs = NULL;
 
-				pstcmd->brp_stlink = NULL;
-				pstcmd->brp_objname[0] = '\0';
-				pstcmd->brp_attrl = NULL;
-
-				pstcmd->brp_objtype = disrui(sock, &rc);
+				i = disrui(sock, &rc); /* read and discard brp_objtype */
 				if (rc == 0)
-					rc = disrfst(sock, PBS_MAXSVRJOBID+1, pstcmd->brp_objname);
+					pstcmd->name = disrst(sock, &rc);
 				if (rc) {
-					(void)free(pstcmd);
+					pbs_statfree(pstcmd);
 					return rc;
 				}
-				rc = decode_DIS_attrl(sock, &pstcmd->brp_attrl);
+				rc = decode_DIS_attrl(sock, &pstcmd->attribs);
 				if (rc) {
-					(void)free(pstcmd);
+					pbs_statfree(pstcmd);
 					return rc;
 				}
 				*pstcx = pstcmd;
-				pstcx  = &pstcmd->brp_stlink;
+				pstcx = &pstcmd->next;
 			}
 			if (reply->brp_is_part)
 				goto again;
@@ -194,7 +207,7 @@ again:
 
 			/* text reply */
 
-		  	reply->brp_un.brp_txt.brp_str = disrcs(sock, &txtlen, &rc);
+			reply->brp_un.brp_txt.brp_str = disrcs(sock, &txtlen, &rc);
 			reply->brp_un.brp_txt.brp_txtlen = txtlen;
 			break;
 
@@ -202,7 +215,7 @@ again:
 
 			/* Locate Job Reply */
 
-			rc = disrfst(sock, PBS_MAXDEST+1, reply->brp_un.brp_locate);
+			rc = disrfst(sock, PBS_MAXDEST + 1, reply->brp_un.brp_locate);
 			break;
 
 		case BATCH_REPLY_CHOICE_RescQuery:
@@ -212,35 +225,32 @@ again:
 			reply->brp_un.brp_rescq.brq_avail = NULL;
 			reply->brp_un.brp_rescq.brq_alloc = NULL;
 			reply->brp_un.brp_rescq.brq_resvd = NULL;
-			reply->brp_un.brp_rescq.brq_down  = NULL;
+			reply->brp_un.brp_rescq.brq_down = NULL;
 			ct = disrui(sock, &rc);
-			if (rc) break;
+			if (rc)
+				break;
 			reply->brp_un.brp_rescq.brq_number = ct;
-			reply->brp_un.brp_rescq.brq_avail  =
-				(int *)malloc(ct * sizeof(int));
+			reply->brp_un.brp_rescq.brq_avail = (int *) malloc(ct * sizeof(int));
 			if (reply->brp_un.brp_rescq.brq_avail == NULL)
 				return DIS_NOMALLOC;
-			reply->brp_un.brp_rescq.brq_alloc  =
-				(int *)malloc(ct * sizeof(int));
+			reply->brp_un.brp_rescq.brq_alloc = (int *) malloc(ct * sizeof(int));
 			if (reply->brp_un.brp_rescq.brq_alloc == NULL)
 				return DIS_NOMALLOC;
-			reply->brp_un.brp_rescq.brq_resvd  =
-				(int *)malloc(ct * sizeof(int));
+			reply->brp_un.brp_rescq.brq_resvd = (int *) malloc(ct * sizeof(int));
 			if (reply->brp_un.brp_rescq.brq_resvd == NULL)
 				return DIS_NOMALLOC;
-			reply->brp_un.brp_rescq.brq_down   =
-				(int *)malloc(ct * sizeof(int));
+			reply->brp_un.brp_rescq.brq_down = (int *) malloc(ct * sizeof(int));
 			if (reply->brp_un.brp_rescq.brq_down == NULL)
 				return DIS_NOMALLOC;
 
-			for (i=0; (i < ct) && (rc == 0); ++i)
-				*(reply->brp_un.brp_rescq.brq_avail+i) = disrui(sock, &rc);
-			for (i=0; (i < ct) && (rc == 0); ++i)
-				*(reply->brp_un.brp_rescq.brq_alloc+i) = disrui(sock, &rc);
-			for (i=0; (i < ct) && (rc == 0); ++i)
-				*(reply->brp_un.brp_rescq.brq_resvd+i) = disrui(sock, &rc);
-			for (i=0; (i < ct) && (rc == 0); ++i)
-				*(reply->brp_un.brp_rescq.brq_down+i)  = disrui(sock, &rc);
+			for (i = 0; (i < ct) && (rc == 0); ++i)
+				*(reply->brp_un.brp_rescq.brq_avail + i) = disrui(sock, &rc);
+			for (i = 0; (i < ct) && (rc == 0); ++i)
+				*(reply->brp_un.brp_rescq.brq_alloc + i) = disrui(sock, &rc);
+			for (i = 0; (i < ct) && (rc == 0); ++i)
+				*(reply->brp_un.brp_rescq.brq_resvd + i) = disrui(sock, &rc);
+			for (i = 0; (i < ct) && (rc == 0); ++i)
+				*(reply->brp_un.brp_rescq.brq_down + i) = disrui(sock, &rc);
 			break;
 
 		case BATCH_REPLY_CHOICE_PreemptJobs:
@@ -248,15 +258,16 @@ again:
 			/* Preempt Jobs Reply */
 			ct = disrui(sock, &rc);
 			reply->brp_un.brp_preempt_jobs.count = ct;
-			if (rc) break;
+			if (rc)
+				break;
 
 			ppj = calloc(sizeof(struct preempt_job_info), ct);
 			reply->brp_un.brp_preempt_jobs.ppj_list = ppj;
 
 			for (i = 0; i < ct; i++) {
 				if (((rc = disrfst(sock, PBS_MAXSVRJOBID + 1, ppj[i].job_id)) != 0) ||
-					((rc = disrfst(sock, PREEMPT_METHOD_HIGH + 1, ppj[i].order)) != 0))
-						return rc;
+				    ((rc = disrfst(sock, PREEMPT_METHOD_HIGH + 1, ppj[i].order)) != 0))
+					return rc;
 			}
 
 			break;

--- a/src/lib/Libifl/enc_reply.c
+++ b/src/lib/Libifl/enc_reply.c
@@ -78,28 +78,27 @@ int encode_DIS_svrattrl(int sock, svrattrl *psattl);
 static int
 encode_DIS_reply_inner(int sock, struct batch_reply *reply)
 {
-	int		    ct;
-	int		    i;
-	struct brp_select  *psel;
-	struct brp_status  *pstat;
-	svrattrl	   *psvrl;
-	preempt_job_info   *ppj;
+	int ct;
+	int i;
+	struct brp_select *psel;
+	struct brp_status *pstat;
+	svrattrl *psvrl;
+	preempt_job_info *ppj;
 
 	int rc;
 
-
 	/* next encode code, auxcode and choice (union type identifier) */
 
-	if ((rc = diswsi(sock, reply->brp_code)) 	||
-		(rc = diswsi(sock, reply->brp_auxcode))	||
-		(rc = diswui(sock, reply->brp_choice)) ||
-		(rc = diswui(sock, reply->brp_is_part)))
-			return rc;
+	if ((rc = diswsi(sock, reply->brp_code)) ||
+	    (rc = diswsi(sock, reply->brp_auxcode)) ||
+	    (rc = diswui(sock, reply->brp_choice)) ||
+	    (rc = diswui(sock, reply->brp_is_part)))
+		return rc;
 
 	switch (reply->brp_choice) {
 
 		case BATCH_REPLY_CHOICE_NULL:
-			break;	/* no more to do */
+			break; /* no more to do */
 
 		case BATCH_REPLY_CHOICE_Queue:
 		case BATCH_REPLY_CHOICE_RdytoCom:
@@ -112,13 +111,7 @@ encode_DIS_reply_inner(int sock, struct batch_reply *reply)
 
 			/* have to send count of number of strings first */
 
-			ct = 0;
-			psel = reply->brp_un.brp_select;
-			while (psel) {
-				++ct;
-				psel = psel->brp_next;
-			}
-			if ((rc = diswui(sock, ct)) != 0)
+			if ((rc = diswui(sock, reply->brp_count)) != 0)
 				return rc;
 
 			psel = reply->brp_un.brp_select;
@@ -136,29 +129,19 @@ encode_DIS_reply_inner(int sock, struct batch_reply *reply)
 			 *
 			 * Server always uses svrattrl form.
 			 * Commands decode into their form.
-			 *
-			 * First need to encode number of status objects and then
-			 * the object itself.
 			 */
 
-			ct = 0;
-			pstat = (struct brp_status *)GET_NEXT(reply->brp_un.brp_status);
-			while (pstat) {
-				++ct;
-				pstat =(struct brp_status *)GET_NEXT(pstat->brp_stlink);
-			}
-			if ((rc = diswui(sock, ct)) != 0)
+			if ((rc = diswui(sock, reply->brp_count)) != 0)
 				return rc;
-			pstat = (struct brp_status *)GET_NEXT(reply->brp_un.brp_status);
+			pstat = (struct brp_status *) GET_NEXT(reply->brp_un.brp_status);
 			while (pstat) {
-				if ((rc = diswui(sock, pstat->brp_objtype))	||
-					(rc = diswst(sock, pstat->brp_objname)))
-						return rc;
+				if ((rc = diswui(sock, pstat->brp_objtype)) || (rc = diswst(sock, pstat->brp_objname)))
+					return rc;
 
-				psvrl = (svrattrl *)GET_NEXT(pstat->brp_attr);
+				psvrl = (svrattrl *) GET_NEXT(pstat->brp_attr);
 				if ((rc = encode_DIS_svrattrl(sock, psvrl)) != 0)
 					return rc;
-				pstat =(struct brp_status *)GET_NEXT(pstat->brp_stlink);
+				pstat = (struct brp_status *) GET_NEXT(pstat->brp_stlink);
 			}
 			break;
 
@@ -166,8 +149,7 @@ encode_DIS_reply_inner(int sock, struct batch_reply *reply)
 
 			/* text reply */
 
-			rc = diswcs(sock, reply->brp_un.brp_txt.brp_str,
-				(size_t)reply->brp_un.brp_txt.brp_txtlen);
+			rc = diswcs(sock, reply->brp_un.brp_txt.brp_str, (size_t) reply->brp_un.brp_txt.brp_txtlen);
 			if (rc)
 				return rc;
 			break;
@@ -187,22 +169,26 @@ encode_DIS_reply_inner(int sock, struct batch_reply *reply)
 			ct = reply->brp_un.brp_rescq.brq_number;
 			if ((rc = diswui(sock, ct)) != 0)
 				return rc;
-			for (i=0; (i<ct) && (rc == 0); ++i) {
-				rc =diswui(sock, *(reply->brp_un.brp_rescq.brq_avail+i));
+			for (i = 0; (i < ct) && (rc == 0); ++i) {
+				rc = diswui(sock, *(reply->brp_un.brp_rescq.brq_avail + i));
 			}
-			if (rc) return rc;
-			for (i=0; (i<ct) && (rc == 0); ++i) {
-				rc =diswui(sock, *(reply->brp_un.brp_rescq.brq_alloc+i));
+			if (rc)
+				return rc;
+			for (i = 0; (i < ct) && (rc == 0); ++i) {
+				rc = diswui(sock, *(reply->brp_un.brp_rescq.brq_alloc + i));
 			}
-			if (rc) return rc;
-			for (i=0; (i<ct) && (rc == 0); ++i) {
-				rc =diswui(sock, *(reply->brp_un.brp_rescq.brq_resvd+i));
+			if (rc)
+				return rc;
+			for (i = 0; (i < ct) && (rc == 0); ++i) {
+				rc = diswui(sock, *(reply->brp_un.brp_rescq.brq_resvd + i));
 			}
-			if (rc) return rc;
-			for (i=0; (i<ct) && (rc == 0); ++i) {
-				rc =diswui(sock, *(reply->brp_un.brp_rescq.brq_down+i));
+			if (rc)
+				return rc;
+			for (i = 0; (i < ct) && (rc == 0); ++i) {
+				rc = diswui(sock, *(reply->brp_un.brp_rescq.brq_down + i));
 			}
-			if (rc) return rc;
+			if (rc)
+				return rc;
 			break;
 
 		case BATCH_REPLY_CHOICE_PreemptJobs:
@@ -215,9 +201,8 @@ encode_DIS_reply_inner(int sock, struct batch_reply *reply)
 				return rc;
 
 			for (i = 0; i < ct; i++) {
-				if (((rc = diswst(sock, ppj[i].job_id)) != 0) ||
-					((rc = diswst(sock, ppj[i].order)) != 0))
-						return rc;
+				if (((rc = diswst(sock, ppj[i].job_id)) != 0) || ((rc = diswst(sock, ppj[i].order)) != 0))
+					return rc;
 			}
 
 			break;

--- a/src/lib/Libifl/int_rdrpy.c
+++ b/src/lib/Libifl/int_rdrpy.c
@@ -159,21 +159,16 @@ PBSD_rdrpy(int c)
  */
 
 void
-PBSD_FreeReply(reply)
-struct batch_reply *reply;
+PBSD_FreeReply(struct batch_reply *reply)
 {
-	struct brp_select   *psel;
-	struct brp_select   *pselx;
-	struct brp_cmdstat  *pstc;
-	struct brp_cmdstat  *pstcx;
-	struct attrl        *pattrl;
-	struct attrl	    *pattrx;
+	struct brp_select *psel;
+	struct brp_select *pselx;
 
 	if (reply == 0)
 		return;
 	if (reply->brp_choice == BATCH_REPLY_CHOICE_Text) {
 		if (reply->brp_un.brp_txt.brp_str) {
-			(void)free(reply->brp_un.brp_txt.brp_str);
+			free(reply->brp_un.brp_txt.brp_str);
 			reply->brp_un.brp_txt.brp_str = NULL;
 			reply->brp_un.brp_txt.brp_txtlen = 0;
 		}
@@ -182,37 +177,21 @@ struct batch_reply *reply;
 		psel = reply->brp_un.brp_select;
 		while (psel) {
 			pselx = psel->brp_next;
-			(void)free(psel);
+			free(psel);
 			psel = pselx;
 		}
 
 	} else if (reply->brp_choice == BATCH_REPLY_CHOICE_Status) {
-		pstc = reply->brp_un.brp_statc;
-		while (pstc) {
-			pstcx = pstc->brp_stlink;
-			pattrl = pstc->brp_attrl;
-			while (pattrl) {
-				pattrx = pattrl->next;
-				if (pattrl->name)
-					(void)free(pattrl->name);
-				if (pattrl->resource)
-					(void)free(pattrl->resource);
-				if (pattrl->value)
-					(void)free(pattrl->value);
-				(void)free(pattrl);
-				pattrl = pattrx;
-			}
-			(void)free(pstc);
-			pstc = pstcx;
-		}
+		if (reply->brp_un.brp_statc)
+			pbs_statfree(reply->brp_un.brp_statc);
 	} else if (reply->brp_choice == BATCH_REPLY_CHOICE_RescQuery) {
-		(void)free(reply->brp_un.brp_rescq.brq_avail);
-		(void)free(reply->brp_un.brp_rescq.brq_alloc);
-		(void)free(reply->brp_un.brp_rescq.brq_resvd);
-		(void)free(reply->brp_un.brp_rescq.brq_down);
+		free(reply->brp_un.brp_rescq.brq_avail);
+		free(reply->brp_un.brp_rescq.brq_alloc);
+		free(reply->brp_un.brp_rescq.brq_resvd);
+		free(reply->brp_un.brp_rescq.brq_down);
 	} else if (reply->brp_choice == BATCH_REPLY_CHOICE_PreemptJobs) {
-		(void)free(reply->brp_un.brp_preempt_jobs.ppj_list);
+		free(reply->brp_un.brp_preempt_jobs.ppj_list);
 	}
 
-	(void)free(reply);
+	free(reply);
 }

--- a/src/lib/Libifl/int_status.c
+++ b/src/lib/Libifl/int_status.c
@@ -177,10 +177,9 @@ random_srv_conn(svr_conn_t *svr_connections)
  *
  */
 struct batch_status *
-PBSD_status(int c, int svr_index, int function, char *objid, struct attrl *attrib, char *extend)
+PBSD_status(int c, int function, char *objid, struct attrl *attrib, char *extend)
 {
 	int rc;
-	struct batch_status *PBSD_status_get(int c, int svr_index);
 
 	/* send the status request */
 
@@ -193,7 +192,7 @@ PBSD_status(int c, int svr_index, int function, char *objid, struct attrl *attri
 	}
 
 	/* get the status reply */
-	return (PBSD_status_get(c, svr_index));
+	return (PBSD_status_get(c));
 }
 
 static void
@@ -435,7 +434,7 @@ PBSD_status_aggregate(int c, int cmd, char *id, struct attrl *attrib, char *exte
 		if (pbs_client_thread_lock_connection(c) != 0)
 			return NULL;
 
-		if ((next = PBSD_status(c, i, cmd, id, attrib, extend))) {
+		if ((next = PBSD_status(c, cmd, id, attrib, extend))) {
 			if (!ret) {
 				ret = next;
 				cur = next->last;
@@ -505,7 +504,7 @@ PBSD_status_random(int c, int cmd, char *id, struct attrl *attrib, char *extend,
 	if (pbs_client_thread_lock_connection(c) != 0)
 		return NULL;
 
-	ret = PBSD_status(c, -1, cmd, id, attrib, extend);
+	ret = PBSD_status(c, cmd, id, attrib, extend);
 
 	/* unlock the thread lock and update the thread context data */
 	if (pbs_client_thread_unlock_connection(c) != 0)
@@ -525,7 +524,7 @@ PBSD_status_random(int c, int cmd, char *id, struct attrl *attrib, char *extend,
  * @retval NULL on failure
  */
 struct batch_status *
-PBSD_status_get(int c, int svr_index)
+PBSD_status_get(int c)
 {
 	struct batch_status *rbsp = NULL;
 	struct batch_reply  *reply;

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -266,7 +266,7 @@ get_hostsockaddr(char *host, struct sockaddr_in *sap)
  * @param[in]   server - The hostname of the pbs server to connect to.
  * @param[in]   port - Port number of the pbs server to connect to.
  * @param[in]   extend_data - a string to send as "extend" data
- * 
+ *
  *
  * @return int
  * @retval >= 0	The physical server socket.
@@ -297,7 +297,7 @@ tcp_connect(char *server, int server_port, char *extend_data)
 	if (sd == -1) {
 		pbs_errno = PBSE_SYSTEM;
 		return -1;
-	}	
+	}
 
 	strncpy(pbs_server, server, sizeof(pbs_server)-1); /* set for error messages from commands */
 	pbs_server[sizeof(pbs_server) - 1] = '\0';
@@ -324,7 +324,7 @@ tcp_connect(char *server, int server_port, char *extend_data)
 		pbs_errno = errno;
 		return -1;
 	}
-	
+
 	/* setup connection level thread context */
 	if (pbs_client_thread_init_connect_context(sd) != 0) {
 		CLOSESOCKET(sd);
@@ -481,7 +481,7 @@ connect_to_server(int idx, svr_conn_t *conn_arr, char *extend_data)
 
 /**
  * @brief
- * 	To connect to all the servers, fill up the connection table 
+ * 	To connect to all the servers, fill up the connection table
  * 	and returns the first connected socket.
  *
  * @param[in]	server_name - name of the server to connect to (NULL if not known)
@@ -492,7 +492,7 @@ connect_to_server(int idx, svr_conn_t *conn_arr, char *extend_data)
  * @retval >0 - success
  * @retval -1 - error
  */
-int 
+int
 connect_to_servers(char *server_name, uint port, char *extend_data)
 {
 	int i = 0;
@@ -592,9 +592,9 @@ __pbs_connect_extend(char *server, char *extend_data)
 		pbs_errno = PBSE_INTERNAL;
 		return -1;
 	}
-	
+
 	/* Returning here  */
-	
+
 	return sock;
 
 	if (pbs_conf.pbs_primary && pbs_conf.pbs_secondary) {

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -249,7 +249,6 @@ done:
 struct batch_status *
 __pbs_selstat(int c, struct attropl *attrib, struct attrl *rattrib, char *extend)
 {
-	extern struct batch_status *PBSD_status_get(int c, int svr_index);
 	int i;
 	struct batch_status *ret = NULL;
 	struct batch_status *next = NULL;
@@ -282,7 +281,7 @@ __pbs_selstat(int c, struct attropl *attrib, struct attrl *rattrib, char *extend
 
 
 		if (PBSD_select_put(c, PBS_BATCH_SelStat, attrib, rattrib, extend) == 0) {
-			if ((next = PBSD_status_get(c, i))) {
+			if ((next = PBSD_status_get(c))) {
 				if (!ret) {
 					ret = next;
 					cur = next->last;

--- a/src/lib/Libifl/pbsD_selectj.c
+++ b/src/lib/Libifl/pbsD_selectj.c
@@ -347,3 +347,61 @@ PBSD_select_put(int c, int type, struct attropl *attrib,
 
 	return 0;
 }
+
+/**
+ * @brief
+ *	-reads selectjob reply from stream
+ *
+ * @param[in] c - communication handle
+ *
+ * @return	string list
+ * @retval	list of strings		success
+ * @retval	NULL			error
+ *
+ */
+static char **
+PBSD_select_get(int c)
+{
+	int   i;
+	struct batch_reply *reply;
+	int   njobs;
+	char *sp;
+	int   stringtot;
+	size_t totsize;
+	struct brp_select *sr;
+	char **retval = NULL;
+
+	/* read reply from stream */
+
+	reply = PBSD_rdrpy(c);
+	if (reply == NULL) {
+		pbs_errno = PBSE_PROTOCOL;
+	} else if (reply->brp_choice != BATCH_REPLY_CHOICE_NULL &&
+		reply->brp_choice != BATCH_REPLY_CHOICE_Text &&
+		reply->brp_choice != BATCH_REPLY_CHOICE_Select) {
+		pbs_errno = PBSE_PROTOCOL;
+	} else if (get_conn_errno(c) == 0) {
+		njobs = reply->brp_count;
+		stringtot = njobs * (PBS_MAXSVRJOBID + 1);
+		totsize = stringtot + (njobs + 1) * (sizeof(char *));
+		retval = (char **)malloc(totsize);
+		if (retval == NULL) {
+			pbs_errno = PBSE_SYSTEM;
+			PBSD_FreeReply(reply);
+			return NULL;
+		}
+		sr = reply->brp_un.brp_select;
+		sp = (char *)retval + (njobs + 1) * sizeof(char *);
+		for (i = 0; i < njobs; i++) {
+			retval[i] = sp;
+			strcpy(sp, sr->brp_jobid);
+			sp += (PBS_MAXSVRJOBID + 1);
+			sr = sr->brp_next;
+		}
+		retval[i] = NULL;
+	}
+
+	PBSD_FreeReply(reply);
+
+	return retval;
+}

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -426,6 +426,7 @@ struct server_info
 	unsigned use_hard_duration:1;	/* use hard duration when creating the calendar */
 	unsigned pset_metadata_stale:1;	/* The placement set meta data is stale and needs to be regenerated before the next use */
 	char *name;			/* name of server */
+	int my_index;			/* my index in svr_conns array */
 	struct schd_resource *res;	/* list of resources */
 	void *liminfo;			/* limit storage information */
 	int flt_lic;			/* number of free floating licences */

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -1164,6 +1164,7 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 	attrp = job->attribs;
 
 	resresv->server = sinfo;
+	resresv->svr_index = sinfo->my_index;
 
 	resresv->is_job = 1;
 
@@ -1216,17 +1217,6 @@ query_job(struct batch_status *job, server_info *sinfo, schd_error *err)
 #ifdef NAS /* localmod 045 */
 			resresv->job->NAS_pri = resresv->job->priority;
 #endif /* localmod 045 */
-		}
-		else if (!strcmp(attrp->name, ATTR_server_index)) {
-			count = strtol(attrp->value, &endp, 10);
-			if (*endp == '\0')
-				resresv->svr_index = count;
-			else
-				resresv->svr_index = -1;
-			if (resresv->svr_index == -1) {
-				free_resource_resv(resresv);
-				return NULL;
-			}
 		}
 		else if (!strcmp(attrp->name, ATTR_qtime)) { /* queue time */
 			count = strtol(attrp->value, &endp, 10);

--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -1655,3 +1655,29 @@ get_svr_index(char *svrname)
 
 	return svrindex;
 }
+
+/**
+ * @brief	Set the server index value for the svr sd
+ *
+ * @param[in]	sd - connection sd to server
+ *
+ * @return int
+ * @retval server index
+ * @retval -1 for failure
+ */
+int
+get_svr_index_bysd(int sd)
+{
+	int i;
+	int svrindex = -1;
+	svr_conn_t *conns = get_conn_servers();
+
+	for (i = 0; i < get_num_servers(); i++) {
+		if (conns[i].sd == sd) {
+			svrindex = i;
+			break;
+		}
+	}
+
+	return svrindex;
+}

--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -289,7 +289,9 @@ add_str_to_unique_array(char ***str_arr, char *str);
  */
 void free_ptr_array (void *inp);
 
-int get_svr_index(char *svrname);
+int get_svr_index(char *);
+void * get_conn_servers(void);
+int get_svr_index_bysd(int);
 
 #ifdef	__cplusplus
 }

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -618,23 +618,13 @@ query_node_info(struct batch_status *node, server_info *sinfo)
 	}
 
 	ninfo->server = sinfo;
+	ninfo->svr_index = sinfo->my_index;
 
 	while (attrp != NULL) {
 		/* Node State... i.e. offline down free etc */
 		if (!strcmp(attrp->name, ATTR_NODE_state))
 			set_node_info_state(ninfo, attrp->value);
 
-		else if (!strcmp(attrp->name, ATTR_server_index)) {
-			count = strtol(attrp->value, &endp, 10);
-			if (*endp == '\0')
-				ninfo->svr_index = count;
-			else
-				ninfo->svr_index = -1;
-			if (ninfo->svr_index == -1) {
-				free_node_info(ninfo);
-				return NULL;
-			}
-		}
 		/* Host name */
 		else if (!strcmp(attrp->name, ATTR_NODE_Mom)) {
 			if (ninfo->mom)
@@ -4871,7 +4861,7 @@ create_execvnode(nspec **ns)
  *
  * @param[in]	execvnode	-	the execvnode to parse
  * @param[in]	sinfo		-	server to get the nodes from
- * @param[in]	sel		- select to map 
+ * @param[in]	sel		- select to map
  *
  * @return	a newly allocated nspec array for the execvnode
  *

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -216,6 +216,13 @@ query_server(status *pol, int pbs_sd)
 		return NULL;
 	}
 
+	if ((sinfo->my_index = get_svr_index_bysd(pbs_sd)) == -1) {
+		pbs_statfree(server);
+		sinfo->fairshare = NULL;
+		free_server(sinfo);
+		return NULL;
+	}
+
 	/* We dup'd the policy structure for the cycle */
 	policy = sinfo->policy;
 

--- a/src/server/dis_read.c
+++ b/src/server/dis_read.c
@@ -315,6 +315,7 @@ decode_DIS_replySvr_inner(int sock, struct batch_reply *reply)
 			pselx = &reply->brp_un.brp_select;
 			ct = disrui(sock, &rc);
 			if (rc) return rc;
+			reply->brp_count = ct;
 
 			while (ct--) {
 				psel = (struct brp_select *)malloc(sizeof(struct brp_select));
@@ -338,6 +339,7 @@ decode_DIS_replySvr_inner(int sock, struct batch_reply *reply)
 			CLEAR_HEAD(reply->brp_un.brp_status);
 			ct = disrui(sock, &rc);
 			if (rc) return rc;
+			reply->brp_count = ct;
 
 			while (ct--) {
 				pstsvr = (struct brp_status *)malloc(sizeof(struct brp_status));
@@ -356,8 +358,7 @@ decode_DIS_replySvr_inner(int sock, struct batch_reply *reply)
 					(void)free(pstsvr);
 					return rc;
 				}
-				append_link(&reply->brp_un.brp_status,
-					&pstsvr->brp_stlink, pstsvr);
+				append_link(&reply->brp_un.brp_status, &pstsvr->brp_stlink, pstsvr);
 				rc = decode_DIS_svrattrl(sock, &pstsvr->brp_attr);
 			}
 			break;

--- a/src/server/hook_func.c
+++ b/src/server/hook_func.c
@@ -2326,6 +2326,7 @@ status_hook(hook *phook, struct batch_request *preq, pbs_list_head *pstathd, cha
 	CLEAR_LINK(pstat->brp_stlink);
 	CLEAR_HEAD(pstat->brp_attr);
 	append_link(pstathd, &pstat->brp_stlink, pstat);
+	preq->rq_reply.brp_count++;
 
 	/* add attributes to the status reply */
 
@@ -2457,6 +2458,7 @@ req_stat_hook(struct batch_request *preq)
 	preply = &preq->rq_reply;
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
+	preply->brp_count = 0;
 
 	if (type == 0) {	/* get status of the one named hook */
 		/* can only stat HOOK_SITE hooks */

--- a/src/server/pbsd_init.c
+++ b/src/server/pbsd_init.c
@@ -547,6 +547,7 @@ pbsd_init(int type)
 
 	/* 3. Set default server attibutes values */
 	memset(&server, 0, sizeof(server));
+	server.sv_started = time(&time_now);	/* time server started */
 	if (server.sv_attr[(int)SVR_ATR_scheduling].at_flags & ATR_VFLAG_SET)
 		a_opt = server.sv_attr[(int)SVR_ATR_scheduling].at_val.at_long;
 

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1623,12 +1623,13 @@ try_db_again:
 	}
 	process_hooks(periodic_req, hook_msg, sizeof(hook_msg), pbs_python_set_interrupt);
 
-	/*
-	 * Make the scheduler (re)-read the configuration
-	 * and fairshare usage.
-	 */
-	(void)contact_sched(SCH_CONFIGURE, NULL, pbs_scheduler_addr, pbs_scheduler_port);
-	(void)contact_sched(SCH_SCHEDULE_NULL, NULL, pbs_scheduler_addr, pbs_scheduler_port);
+	if (server_init_type != RECOV_CREATE) {
+		/*
+		 * Make the scheduler (re)-read the configuration
+		 * and fairshare usage.
+		 */
+		set_scheduler_flag(SCH_CONFIGURE, dflt_scheduler);
+	}
 
 	/*
 	 * main loop of server

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -715,28 +715,26 @@ int
 main(int argc, char **argv)
 {
 	char *nodename = NULL;
-	int			are_primary;
-	int			c, rc;
-	int			i;
-	int			tppfd;		/* fd to receive is HELLO's */
-	struct			tpp_config tpp_conf;
-	char			lockfile[MAXPATHLEN+1];
-	char			**origevp;
-	char			*pc;
-	pbs_queue		*pque;
-	char			*servicename;
-	time_t			svrlivetime;
-	int			sock;
-	struct stat 		sb_sa;
-	struct batch_request	*periodic_req;
-	char			hook_msg[HOOK_MSG_SIZE];
-	pbs_sched		*psched;
-	char			*keep_daemon_name = NULL;
-
-	pid_t			sid = -1;
-
-	long			*state;
-	time_t			waittime;
+	int are_primary;
+	int c, rc;
+	int i;
+	int tppfd; /* fd to receive is HELLO's */
+	struct tpp_config tpp_conf;
+	char lockfile[MAXPATHLEN + 1];
+	char **origevp;
+	char *pc;
+	pbs_queue *pque;
+	char *servicename;
+	time_t svrlivetime;
+	int sock;
+	struct stat sb_sa;
+	struct batch_request *periodic_req;
+	char hook_msg[HOOK_MSG_SIZE];
+	pbs_sched *psched;
+	char *keep_daemon_name = NULL;
+	pid_t sid = -1;
+	long *state;
+	time_t waittime;
 #ifdef _POSIX_MEMLOCK
 	int			do_mlockall = 0;
 #endif	/* _POSIX_MEMLOCK */
@@ -1016,8 +1014,6 @@ main(int argc, char **argv)
 		log_err(errno, msg_daemonname, log_buffer);
 		return (2);
 	}
-
-	server.sv_started = time(&time_now);	/* time server started */
 
 	CLEAR_HEAD(svr_requests);
 	CLEAR_HEAD(task_list_immed);
@@ -1627,13 +1623,12 @@ try_db_again:
 	}
 	process_hooks(periodic_req, hook_msg, sizeof(hook_msg), pbs_python_set_interrupt);
 
-	if (server_init_type != RECOV_CREATE) {
-		/*
-		 * Make the scheduler (re)-read the configuration
-		 * and fairshare usage.
-		 */
-		set_scheduler_flag(SCH_CONFIGURE, dflt_scheduler);
-	}
+	/*
+	 * Make the scheduler (re)-read the configuration
+	 * and fairshare usage.
+	 */
+	(void)contact_sched(SCH_CONFIGURE, NULL, pbs_scheduler_addr, pbs_scheduler_port);
+	(void)contact_sched(SCH_SCHEDULE_NULL, NULL, pbs_scheduler_addr, pbs_scheduler_port);
 
 	/*
 	 * main loop of server

--- a/src/server/reply_send.c
+++ b/src/server/reply_send.c
@@ -267,6 +267,7 @@ reply_send_status_part(struct batch_request *preq)
 		reply_free(&preq->rq_reply);
 		preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 		CLEAR_HEAD(preply->brp_un.brp_status);
+		preply->brp_count = 0;
 	}
 	return rc;
 }

--- a/src/server/req_message.c
+++ b/src/server/req_message.c
@@ -361,6 +361,8 @@ req_relnodesjob(struct batch_request *preq)
 
 	rc = free_sister_vnodes(pjob, nodeslist, keep_select, msg, LOG_BUF_SIZE, preq);
 
+	job_save_db(pjob); /* we must save the updates anyway, if any */
+
 	if (rc != 0) {
 		reply_text(preq, PBSE_SYSTEM, msg);
 	}

--- a/src/server/req_select.c
+++ b/src/server/req_select.c
@@ -348,7 +348,6 @@ req_selectjobs(struct batch_request *preq)
 	struct select_list *selistp;
 	pbs_sched *psched;
 	long job_limit = 0;
-	int count = 0;
 	long jcount = 0;
 
 	job_limit = server.sv_attr[SVR_ATR_job_stat_limit].at_val.at_long;
@@ -409,6 +408,7 @@ req_selectjobs(struct batch_request *preq)
 		CLEAR_HEAD(preply->brp_un.brp_status);
 	}
 	pselx = &preply->brp_un.brp_select;
+	preply->brp_count = 0;
 
 	/* now start checking for jobs that match the selection criteria */
 	if (pque)
@@ -434,7 +434,7 @@ req_selectjobs(struct batch_request *preq)
 
 					/* Select Jobs Reply */
 
-					preq->rq_reply.brp_auxcode += add_select_array_entries(pjob, dosubjobs, pstate, &pselx, selistp);
+					preply->brp_count += add_select_array_entries(pjob, dosubjobs, pstate, &pselx, selistp);
 
 				} else if ((pjob->ji_qs.ji_svrflags & JOB_SVFLG_SubJob) == 0 || dosubjobs == 2) {
 
@@ -444,13 +444,12 @@ req_selectjobs(struct batch_request *preq)
 					if (dosubjobs == 1 && pjob->ji_ajtrk) {
 						for (i = 0; i < pjob->ji_ajtrk->tkm_ct; i++) {
 							if (pstate == 0 || chk_job_statenum(pjob->ji_ajtrk->tkm_tbl[i].trk_status, pstate)) {
-								if (count >= MAX_JOBS_PER_REPLY) {
+								if (preply->brp_count >= MAX_JOBS_PER_REPLY) {
 									rc = reply_send_status_part(preq);
 									if (rc != PBSE_NONE)
 										return;
-									count = 0;
+									preply->brp_count = 0;
 								}
-								count++;
 								rc = status_subjob(pjob, preq, plist, i, &preply->brp_un.brp_status, &bad);
 								if (rc && rc != PBSE_PERM)
 									goto out;
@@ -471,11 +470,10 @@ req_selectjobs(struct batch_request *preq)
 			pjob = (job *) GET_NEXT(pjob->ji_jobque);
 		else
 			pjob = (job *) GET_NEXT(pjob->ji_alljobs);
-		if (preq->rq_type != PBS_BATCH_SelectJobs && count++ >= MAX_JOBS_PER_REPLY && pjob) {
+		if (preq->rq_type != PBS_BATCH_SelectJobs && preply->brp_count >= MAX_JOBS_PER_REPLY && pjob) {
 			rc = reply_send_status_part(preq);
 			if (rc != PBSE_NONE)
 				return;
-			count = 0;
 		}
 	}
 out:

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -138,14 +138,13 @@ static int status_resv(resc_resv *, struct batch_request *, pbs_list_head *);
  * @param[in]     pjob       - pointer to the job to be statused
  * @param[in]     dohistjobs - flag to include job if it is a history job
  * @param[in]     dosubjobs  - flag to expand a Array job to include all subjobs
- * @param[in/out] count      - count of total jobs in reply (used in sending part status reply)
  *
  * @return int
  * @retval PBSE_NONE  - no error
  * @retval !PBSE_NONE - PBS error code to return to client
  */
 static int
-do_stat_of_a_job(struct batch_request *preq, job *pjob, int dohistjobs, int dosubjobs, int *count)
+do_stat_of_a_job(struct batch_request *preq, job *pjob, int dohistjobs, int dosubjobs)
 {
 	int indx;
 	svrattrl *pal;
@@ -163,11 +162,10 @@ do_stat_of_a_job(struct batch_request *preq, job *pjob, int dohistjobs, int dosu
 		rc = status_job(pjob, preq, pal, &preply->brp_un.brp_status, &bad);
 		if (dosubjobs && (pjob->ji_qs.ji_svrflags & JOB_SVFLG_ArrayJob) && (rc == PBSE_NONE || rc != PBSE_PERM) && pjob->ji_ajtrk != NULL) {
 			for (indx = 0; indx < pjob->ji_ajtrk->tkm_ct; ++indx) {
-				if ((*count)++ >= MAX_JOBS_PER_REPLY) {
+				if (preply->brp_count >= MAX_JOBS_PER_REPLY) {
 					rc = reply_send_status_part(preq);
 					if (rc != PBSE_NONE)
 						return rc;
-					*count = 0;
 				}
 				rc = status_subjob(pjob, preq, pal, indx, &preply->brp_un.brp_status, &bad);
 				if (rc && rc != PBSE_PERM)
@@ -192,14 +190,13 @@ do_stat_of_a_job(struct batch_request *preq, job *pjob, int dohistjobs, int dosu
  * @param[in]     name       - job id to be statused
  * @param[in]     dohistjobs - flag to include job if it is a history job
  * @param[in]     dosubjobs  - flag to expand a Array job to include all subjobs
- * @param[in/out] count      - count of total jobs in reply (used in sending part status reply)
  *
  * @return int
  * @retval PBSE_NONE  - no error
  * @retval !PBSE_NONE - PBS error code to return to client
  */
 static int
-stat_a_jobidname(struct batch_request *preq, char *name, int dohistjobs, int dosubjobs, int *count)
+stat_a_jobidname(struct batch_request *preq, char *name, int dohistjobs, int dosubjobs)
 {
 	int i;
 	char *pc;
@@ -231,7 +228,7 @@ stat_a_jobidname(struct batch_request *preq, char *name, int dohistjobs, int dos
 			return PBSE_UNKJOBID;
 		else if (!dohistjobs && (rc = svr_chk_histjob(pjob)) != PBSE_NONE)
 			return rc;
-		return do_stat_of_a_job(preq, pjob, dohistjobs, dosubjobs, count);
+		return do_stat_of_a_job(preq, pjob, dohistjobs, dosubjobs);
 	} else {
 		/* range of sub jobs */
 		range = get_index_from_jid(name);
@@ -257,11 +254,10 @@ stat_a_jobidname(struct batch_request *preq, char *name, int dohistjobs, int dos
 				int idx = numindex_to_offset(pjob, i);
 				if (idx == -1)
 					continue;
-				if ((*count)++ >= MAX_JOBS_PER_REPLY) {
+				if (preply->brp_count >= MAX_JOBS_PER_REPLY) {
 					rc = reply_send_status_part(preq);
 					if (rc != PBSE_NONE)
 						return rc;
-					*count = 0;
 				}
 				rc = status_subjob(pjob, preq, pal, idx, &preply->brp_un.brp_status, &bad);
 				if (rc && rc != PBSE_PERM)
@@ -304,7 +300,6 @@ req_stat_job(struct batch_request *preq)
 	int rc = 0;
 	int type = 0;
 	char *pnxtjid = NULL;
-	int count = 0;
 
 	/* check for any extended flag in the batch request. 't' for
 	 * the sub jobs. If 'x' is there, then check if the server is
@@ -363,6 +358,7 @@ req_stat_job(struct batch_request *preq)
 	preply = &preq->rq_reply;
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
+	preply->brp_count = 0;
 
 	rc = PBSE_NONE;
 	if (type == 1) {
@@ -386,17 +382,16 @@ req_stat_job(struct batch_request *preq)
 	} else {
 		pjob = (job *) GET_NEXT(type == 2 ? pque->qu_jobs : svr_alljobs);
 		while (pjob) {
-			rc = do_stat_of_a_job(preq, pjob, dohistjobs, dosubjobs, &count);
+			rc = do_stat_of_a_job(preq, pjob, dohistjobs, dosubjobs);
 			if (rc != PBSE_NONE) {
 				req_reject(rc, bad, preq);
 				return;
 			}
 			pjob = (job *) GET_NEXT(type == 2 ? pjob->ji_jobque : pjob->ji_alljobs);
-			if (count++ >= MAX_JOBS_PER_REPLY && pjob) {
+			if (preply->brp_count >= MAX_JOBS_PER_REPLY && pjob) {
 				rc = reply_send_status_part(preq);
 				if (rc != PBSE_NONE)
 					return;
-				count = 0;
 			}
 		}
 	}
@@ -450,6 +445,7 @@ req_stat_que(struct batch_request *preq)
 	preply = &preq->rq_reply;
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
+	preply->brp_count = 0;
 
 	if (type == 0) {	/* get status of the one named queue */
 		rc = status_que(pque, preq, &preply->brp_un.brp_status);
@@ -522,6 +518,7 @@ status_que(pbs_queue *pque, struct batch_request *preq, pbs_list_head *pstathd)
 	CLEAR_LINK(pstat->brp_stlink);
 	CLEAR_HEAD(pstat->brp_attr);
 	append_link(pstathd, &pstat->brp_stlink, pstat);
+	preq->rq_reply.brp_count++;
 
 	/* add attributes to the status reply */
 
@@ -586,6 +583,7 @@ req_stat_node(struct batch_request *preq)
 	preply = &preq->rq_reply;
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
+	preply->brp_count = 0;
 
 	if (type == 0) {		/* get status of the named node */
 		rc = status_node(pnode, preq, &preply->brp_un.brp_status);
@@ -678,6 +676,7 @@ status_node(struct pbsnode *pnode, struct batch_request *preq, pbs_list_head *ps
 	/*the request's reply substructure                         */
 
 	append_link(pstathd, &pstat->brp_stlink, pstat);
+	preq->rq_reply.brp_count++;
 
 	/*point to the list of node-attributes about which we want status*/
 	/*hang that status information from the brp_attr field for this  */
@@ -766,6 +765,7 @@ req_stat_svr(struct batch_request *preq)
 	preply = &preq->rq_reply;
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
+	preply->brp_count = 0;
 
 	pstat = (struct brp_status *)malloc(sizeof(struct brp_status));
 	if (pstat == NULL) {
@@ -778,6 +778,7 @@ req_stat_svr(struct batch_request *preq)
 	pstat->brp_objtype = MGR_OBJ_SERVER;
 	CLEAR_HEAD(pstat->brp_attr);
 	append_link(&preply->brp_un.brp_status, &pstat->brp_stlink, pstat);
+	preply->brp_count++;
 
 	/* add attributes to the status reply */
 
@@ -821,6 +822,7 @@ status_sched(pbs_sched *psched, struct batch_request *preq, pbs_list_head *pstat
 	CLEAR_LINK(pstat->brp_stlink);
 	CLEAR_HEAD(pstat->brp_attr);
 	append_link(pstathd, &pstat->brp_stlink, pstat);
+	preq->rq_reply.brp_count++;
 
 
 	bad = 0;
@@ -857,6 +859,7 @@ req_stat_sched(struct batch_request *preq)
 	preply = &preq->rq_reply;
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
+	preply->brp_count = 0;
 
 	for (psched = (pbs_sched *) GET_NEXT(svr_allscheds);
 			(psched != NULL);
@@ -975,6 +978,7 @@ req_stat_resv(struct batch_request * preq)
 	preply = &preq->rq_reply;
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
+	preply->brp_count = 0;
 
 	if (type == 0) {
 		/* get status of the specifically named reservation */
@@ -1037,6 +1041,7 @@ status_resv(resc_resv *presv, struct batch_request *preq, pbs_list_head *pstathd
 	CLEAR_LINK(pstat->brp_stlink);
 	CLEAR_HEAD(pstat->brp_attr);
 	append_link(pstathd, &pstat->brp_stlink, pstat);
+	preq->rq_reply.brp_count++;
 
 	/*finally, add the requested attributes to the status reply*/
 
@@ -1120,6 +1125,7 @@ status_resc(struct resource_def *prd, struct batch_request *preq, pbs_list_head 
 			return PBSE_SYSTEM;
 	}
 	append_link(pstathd, &pstat->brp_stlink, pstat);
+	preq->rq_reply.brp_count++;
 	return 0;
 }
 
@@ -1174,6 +1180,7 @@ req_stat_resc(struct batch_request *preq)
 	preply = &preq->rq_reply;
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
+	preply->brp_count = 0;
 
 	if (type == 0) {	/* get status of the one named resource */
 		rc = status_resc(prd, preq, &preply->brp_un.brp_status, private);

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -370,7 +370,7 @@ req_stat_job(struct batch_request *preq)
 		 */
 		pnxtjid = name;
 		while ((name = parse_comma_string_r(&pnxtjid)) != NULL) {
-			if ((rc = stat_a_jobidname(preq, name, dohistjobs, dosubjobs, &count)) == PBSE_NONE)
+			if ((rc = stat_a_jobidname(preq, name, dohistjobs, dosubjobs)) == PBSE_NONE)
 				at_least_one_success = 1;
 		}
 		if (at_least_one_success == 1)

--- a/src/server/stat_job.c
+++ b/src/server/stat_job.c
@@ -300,6 +300,7 @@ status_job(job *pjob, struct batch_request *preq, svrattrl *pal, pbs_list_head *
 	(void)strcpy(pstat->brp_objname, pjob->ji_qs.ji_jobid);
 	CLEAR_HEAD(pstat->brp_attr);
 	append_link(pstathd, &pstat->brp_stlink, pstat);
+	preq->rq_reply.brp_count++;
 
 	/* add attributes to the status reply */
 
@@ -390,6 +391,7 @@ status_subjob(job *pjob, struct batch_request *preq, svrattrl *pal, int subj, pb
 	(void)strcpy(pstat->brp_objname, mk_subjob_id(pjob, subj));
 	CLEAR_HEAD(pstat->brp_attr);
 	append_link(pstathd, &pstat->brp_stlink, pstat);
+	preq->rq_reply.brp_count++;
 
 	/* add attributes to the status reply */
 

--- a/src/tools/Makefile.am
+++ b/src/tools/Makefile.am
@@ -110,7 +110,7 @@ pbs_probe_LDADD = \
 	${common_libs} \
 	@PYTHON_LDFLAGS@ \
 	@PYTHON_LIBS@
-pbs_probe_SOURCES = pbs_probe.c
+pbs_probe_SOURCES = pbs_probe.c $(top_srcdir)/src/lib/Libcmds/cmds_common.c
 
 pbs_python_CPPFLAGS =  \
 	-DPBS_PYTHON=1.1 \

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -641,7 +641,7 @@
 {
    From PBS - Suppress intentional unfreed memory of auth struct inside global tpp_conf struct
    Memcheck:Leak
-   fun:calloc
+   fun:malloc
    fun:make_auth_config
    fun:set_tpp_config
    fun:main
@@ -669,5 +669,40 @@
    fun:calloc
    fun:tpp_get_tls
    fun:work
+   ...
+}
+{
+   From PBS - Suppress uninitialized job fs structure in mom
+   Memcheck:Param
+   write(buf)
+   ...
+   fun:job_save_fs
+   ...
+}
+{
+   From PBS - Suppress hook allocated buffer
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:hook_alloc
+   fun:hook_recov
+   ...
+}
+{
+   From PBS - Suppress hook allocated buffer
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:hook_alloc
+   fun:mgr_hook_create
+   ...
+}
+{
+   From PBS - Suppress uninitialized DIS buffer
+   Memcheck:Param
+   write(buf)
+   ...
+   fun:__send_pkt
+   fun:dis_flush
    ...
 }


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Cherry-pick stat fix new changes and svr shutdown optimization from master
* Optimized setting svr_index on each job/node in sched

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* For optimization svr_index, simply set my_index on sinfo after query_server based on socket used in IFL (and for this we only loop through svr_conns array 1 time per server and compare pbs_sd with svr_conn_t->sd), then in query job/node, assign sinfo->my_index to job/node->svr_index

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
* coming soon


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
