### PR TITLE
Using TPP for inter-server communication

### DIFF
--- a/src/include/libauth.h
+++ b/src/include/libauth.h
@@ -42,8 +42,6 @@
 extern "C" {
 #endif
 
-#include "log.h"
-
 #undef DLLEXPORT
 #ifdef WIN32
 #define DLLEXPORT __declspec(dllexport)

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -319,7 +319,7 @@ extern void PBS_free_aopl(struct attropl *);
 extern void advise(char *, ...);
 extern int PBSD_rdytocmt(int, char *, int, char **);
 extern int PBSD_commit(int, char *, int, char **);
-extern int PBSD_commit_and_run(int c, char *jobid, char *dest);
+extern int PBSD_commit_and_run(int, char *, int, char**, char *);
 extern int PBSD_runjob(int, char *, char *, char *, int);
 extern int PBSD_jcred(int, int, char *, int, int, char **);
 extern int PBSD_jscript(int, char *, int, char **);

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -331,8 +331,6 @@ extern char *netaddr(struct sockaddr_in *);
 extern unsigned long crc_file(char *fname);
 extern int get_fullhostname(char *, char *, int);
 
-extern int get_msvr_mode(void);
-
 #ifdef _USRDLL
 #ifdef DLL_EXPORT
 #define DECLDIR __declspec(dllexport)

--- a/src/include/net_connect.h
+++ b/src/include/net_connect.h
@@ -204,9 +204,6 @@ int  wait_request(time_t waittime, void *priority_context);
 extern void *priority_context;
 void net_add_close_func(int, void(*)(int));
 extern  pbs_net_t  get_addr_of_nodebyname(char *name, unsigned int *port);
-extern void set_peer_server_conn(int);
-extern int get_peer_server_sock(pbs_net_t, unsigned int);
-int is_socket_up(int fd);
 
 conn_t *get_conn(int sock); /* gets the connection, for a given socket id */
 void connection_idlecheck(void);

--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -417,7 +417,7 @@ extern  void	momptr_down(mominfo_t *, char *);
 extern  void	momptr_offline_by_mom(mominfo_t *, char *);
 extern  void	momptr_clear_offline_by_mom(mominfo_t *, char *);
 extern  void	   delete_mom_entry(mominfo_t *);
-extern  mominfo_t *create_svrmom_entry(char *, unsigned int, unsigned long *);
+extern  mominfo_t *create_svrmom_entry(char *, unsigned int, unsigned long *, int);
 extern  void       delete_svrmom_entry(mominfo_t *);
 extern  int	legal_vnode_char(char, int);
 extern 	char	*parse_node_token(char *, int, int *, char *);

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -187,7 +187,7 @@ extern int			license_sanity_check(void);
 extern void			memory_debug_log(struct work_task *ptask);
 
 /* multi-server functions */
-extern void *	is_peersvr(struct sockaddr_in*);
+extern void *	get_peersvr(struct sockaddr_in*);
 extern int	msvr_mode(void);
 extern void *	create_svr_entry(char *, unsigned int);
 extern int	init_msi();

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -186,6 +186,12 @@ extern void			set_attr_svr(attribute *pattr, attribute_def *pdef, char *value);
 extern int			license_sanity_check(void);
 extern void			memory_debug_log(struct work_task *ptask);
 
+/* multi-server functions */
+extern void *	is_peersvr(struct sockaddr_in*);
+extern int	msvr_mode(void);
+extern void *	create_svr_entry(char *, unsigned int);
+extern int	init_msi();
+
 #ifdef	__cplusplus
 }
 #endif

--- a/src/lib/Libifl/int_status.c
+++ b/src/lib/Libifl/int_status.c
@@ -69,10 +69,12 @@ static char *statename[] = { "Transit", "Queued", "Held", "Waiting",
 
 /**
  * @brief
- *	decoded state attribute to count array
+ *	decode_states - decoded state attribute to count array
  *
  * @param[in] string - string holding state of job
  * @param[out] count    - count array having job per state
+ * 
+ * @return void
  *
  */
 static void
@@ -112,6 +114,17 @@ decode_states(char *string, long *count)
 	}
 }
 
+/**
+ * @brief
+ *	encode_states - Encode state from two state count arrays
+ *
+ * @param[in,out] val - reference to pointer which will get freed and new value gets allocated
+ * @param[in] cur    - count array having job per state
+ * @param[in] next    - count array having job per state
+ * 
+ * @return void
+ *
+ */
 static void
 encode_states(char **val, long *cur, long *nxt)
 {
@@ -130,8 +143,14 @@ encode_states(char **val, long *cur, long *nxt)
 
 /**
  * @brief
+ * 	get_available_conn:
  *	get one of the available connection from multisvr sd
  *
+ * @param[in] svr_connections - pointer to array of server connections
+ * 
+ * @return int
+ * @retval -1: error
+ * @retval != -1 fd corresponding to the connection
  */
 int
 get_available_conn(svr_conn_t *svr_connections)
@@ -147,8 +166,13 @@ get_available_conn(svr_conn_t *svr_connections)
 
 /**
  * @brief
+ * random_srv_conn:
  *	get random server sd - It will choose a random sd from available no of servers.
- *
+ * @param[in] svr_connections - pointer to array of server connections
+ * 
+ * @return int
+ * @retval -1: error
+ * @retval != -1: fd corresponding to the connection
  */
 int
 random_srv_conn(svr_conn_t *svr_connections)
@@ -199,6 +223,16 @@ PBSD_status(int c, int svr_index, int function, char *objid, struct attrl *attri
 	return (PBSD_status_get(c, svr_index));
 }
 
+/**
+ * @brief
+ * aggr_job_ct:
+ *	aggregate the job counts attribute of servers
+ *	total_jobs and state_counts are the attributes aggregated here.
+ * @param[in] cur - batch status to first server
+ * @param[in] next - batch status to second server
+ * 
+ * @return void
+ */
 static void
 aggr_job_ct(struct batch_status *cur, struct batch_status *nxt)
 {
@@ -251,6 +285,18 @@ aggr_job_ct(struct batch_status *cur, struct batch_status *nxt)
 #define STRING 2
 #define SIZE 3
 
+/**
+ * @brief
+ * assess_type:
+ *	Assess the type of the value and return the value along with
+ *	the references passed to it.
+ * @param[in] val - value for which type needs to be assessed
+ * @param[out] type - The type of val: can be long, double, size or string.
+ * @param[out] val_double - double value in case if the type is double or floating number.
+ * @param[out] val_long - long in case if the type is long or size
+ * 
+ * @return void
+ */
 static void
 assess_type(char *val, int *type, double *val_double, long *val_long)
 {
@@ -278,6 +324,17 @@ struct attrl_holder {
 	struct attrl_holder *next;
 };
 
+/**
+ * @brief
+ * accumulate_values:
+ *	Accumulate values in resources assigned attribute in b
+ * @param[in] a - input list of type attrl_holder. 
+ * 		It will contain only resources assigned those needs to be added with the corresponding in b.
+ * @param[in] b - attribute list which needs to be added with a. This function does not iterate through the list.
+ * @param[in,out] orig - original list which is the superset of a. b will be appended to orig if could not find in a.
+ * 
+ * @return void
+ */
 static void
 accumulate_values(struct attrl_holder *a, struct attrl *b, struct attrl *orig)
 {
@@ -333,6 +390,17 @@ accumulate_values(struct attrl_holder *a, struct attrl *b, struct attrl *orig)
 	}
 }
 
+/**
+ * @brief
+ * aggr_resc_ct:
+ *	Aggregate all resources assigned attributes from two batch status.
+ * @param[in] st1 - input list of type attrl_holder. 
+ * 		It will contain only resources assigned those needs to be added with the corresponding in b.
+ * @param[in] b - attribute list which needs to be added with a. This function does not iterate through the list.
+ * @param[in,out] orig - original list which is the superset of a. b will be appended to orig if could not find in a.
+ * 
+ * @return void
+ */
 static void
 aggr_resc_ct(struct batch_status *st1, struct batch_status *st2)
 {
@@ -371,23 +439,44 @@ aggr_resc_ct(struct batch_status *st1, struct batch_status *st2)
 	}
 }
 
+/**
+ * @brief
+ * append_bs:
+ *	append b to end of a. also remove references of b from its batch status
+ * @param[in,out] a - attr list where b needs to be appended
+ * @param[in] b - batch status which needs to be appended to a
+ * @param[in,out] prev_b - previous list element of b for which references needs to be updated
+ * @param[in] head_a - head element of list contains a
+ * @param[in,out] head_b - reference to head element of list contains b. Reference is updated if prev_b is null
+ * 
+ * @return void
+ */
 static void
-append_bs(struct batch_status *a, struct batch_status *b, struct batch_status *prev, struct batch_status *sv1, struct batch_status **sv2)
+append_bs(struct batch_status *a, struct batch_status *b, struct batch_status *prev_b, struct batch_status *head_a, struct batch_status **head_b)
 {
 	if (!a) {
-		for (a = sv1; a->next; a = a->next)
+		for (a = head_a; a->next; a = a->next)
 			;
 		a->next = b;
-		if (prev) {
-			prev->next = b->next;
-			prev->last = b->last;
+		if (prev_b) {
+			prev_b->next = b->next;
+			prev_b->last = b->last;
 		} else {
-			*sv2 = b->next;
+			*head_b = b->next;
 		}
 		b->next = NULL;
 	}
 }
 
+/**
+ * @brief
+ * aggregate_queue:
+ *	aggregate two queues reported by two server instances
+ * @param[in,out] sv1 - server1 list. This will be also the final aggregated list.
+ * @param[in,out] sv2 - Server2 list. Passing reference as the first element can be moved to sv1
+ * 
+ * @return void
+ */
 static void
 aggregate_queue(struct batch_status *sv1, struct batch_status **sv2)
 {
@@ -409,6 +498,15 @@ aggregate_queue(struct batch_status *sv1, struct batch_status **sv2)
 	}
 }
 
+/**
+ * @brief
+ * aggregate_svr:
+ *	aggregate two servers reported by two server instances
+ * @param[in,out] sv1 - server1 list. This will be also the final aggregated list.
+ * @param[in] sv2 - Server2 list.
+ * 
+ * @return void
+ */
 static void
 aggregate_svr(struct batch_status *sv1, struct batch_status *sv2)
 {

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2190,18 +2190,6 @@ crc_file(char *filepath)
 
 /**
  * @brief
- * 	Return multiserver mode
- *
- * @return int
- */
-int
-get_msvr_mode(void)
-{
-	return 0;
-}
-
-/**
- * @brief
  *	get_num_servers - Getter function to get number of servers configured in PBS complex.
  *
  */

--- a/src/server/Makefile.am
+++ b/src/server/Makefile.am
@@ -137,7 +137,8 @@ pbs_server_bin_SOURCES = \
 	svr_resccost.c \
 	svr_credfunc.c \
 	user_func.c \
-	vnparse.c
+	vnparse.c \
+	multi_svr.c
 
 pbs_comm_CPPFLAGS = \
 	-I$(top_srcdir)/src/include \

--- a/src/server/mom_info.c
+++ b/src/server/mom_info.c
@@ -100,6 +100,7 @@ extern char	*path_hooks_rescdef;
 extern char	*msg_new_inventory_mom;
 
 extern int remove_mom_ipaddresses_list(mominfo_t *pmom);
+extern int make_host_addresses_list(char *phost, u_long **pul);
 
 /*
  * The following function are used by both the Server and Mom
@@ -340,13 +341,16 @@ find_mom_entry(char *hostname, unsigned int port)
  */
 
 mominfo_t *
-create_svrmom_entry(char *hostname, unsigned int port, unsigned long *pul)
+create_svrmom_entry(char *hostname, unsigned int port, unsigned long *pul, int peer_svr)
 {
 	mominfo_t     *pmom;
 	mom_svrinfo_t *psvrmom;
 	extern struct tree  *ipaddrs;
 
-	pmom = create_mom_entry(hostname, port);
+	if (peer_svr)
+		pmom = create_svr_entry(hostname, port);
+	else
+		pmom = create_mom_entry(hostname, port);
 	if (pmom == NULL) {
 		free(pul);
 		return pmom;
@@ -398,6 +402,19 @@ create_svrmom_entry(char *hostname, unsigned int port, unsigned long *pul)
 	}
 
 	return pmom;
+}
+
+mominfo_t*
+create_svrmom_struct(char *phost, int port)
+{
+	u_long		*pul = NULL;
+
+	if (make_host_addresses_list(phost, &pul)) {
+		free(pul);
+		return NULL;
+	}
+
+	return create_svrmom_entry(phost, port, pul, 1);
 }
 
 /**

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 1994-2020 Altair Engineering, Inc.
+ * For more information, contact Altair at www.altair.com.
+ *
+ * This file is part of both the OpenPBS software ("OpenPBS")
+ * and the PBS Professional ("PBS Pro") software.
+ *
+ * Open Source License Information:
+ *
+ * OpenPBS is free software. You can redistribute it and/or modify it under
+ * the terms of the GNU Affero General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or (at your
+ * option) any later version.
+ *
+ * OpenPBS is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * Commercial License Information:
+ *
+ * PBS Pro is commercially licensed software that shares a common core with
+ * the OpenPBS software.  For a copy of the commercial license terms and
+ * conditions, go to: (http://www.pbspro.com/agreement.html) or contact the
+ * Altair Legal Department.
+ *
+ * Altair's dual-license business model allows companies, individuals, and
+ * organizations to create proprietary derivative works of OpenPBS and
+ * distribute them - whether embedded or bundled with other software -
+ * under a commercial license agreement.
+ *
+ * Use of Altair's trademarks, including but not limited to "PBS™",
+ * "OpenPBS®", "PBS Professional®", and "PBS Pro™" and Altair's logos is
+ * subject to Altair's trademark licensing policies.
+ */
+
+/**
+ *
+ * @brief
+ *		all the functions related to multi-server.
+ *
+ */
+
+#include	"pbs_nodes.h"
+
+
+extern char server_host[];
+extern uint	pbs_server_port_dis;
+extern mominfo_t* create_svrmom_struct(char *phost, int port);
+
+
+
+mominfo_t *
+is_peersvr(struct sockaddr_in *addr)
+{
+	mominfo_t *pmom;
+
+	if ((pmom = tfind2(ntohl(addr->sin_addr.s_addr), ntohs(addr->sin_port),
+			   &ipaddrs)) != NULL) {
+		if (pmom->mi_rmport == pmom->mi_port)
+			return pmom;
+	}
+
+	return NULL;
+}
+
+/**
+ * @brief
+ * 	Return multiserver mode
+ *
+ * @return int
+ */
+int
+msvr_mode(void)
+{
+	return (get_num_servers() > 1);
+}
+
+struct peersvr_list {
+	struct peersvr_list *next;
+	mominfo_t  *pmom;
+};
+
+static struct peersvr_list *peersvrl;
+
+mominfo_t *
+create_svr_entry(char *hostname, unsigned int port)
+{
+	mominfo_t *pmom;
+
+	pmom = (mominfo_t *) malloc(sizeof(mominfo_t));
+	if (pmom) {
+		strncpy(pmom->mi_host, hostname, PBS_MAXHOSTNAME);
+		pmom->mi_host[PBS_MAXHOSTNAME] = '\0';
+		pmom->mi_port = port;
+		pmom->mi_rmport = port;
+		pmom->mi_modtime = (time_t) 0;
+		pmom->mi_data = NULL;
+		pmom->mi_action = NULL;
+		pmom->mi_num_action = 0;
+	}
+
+	if (peersvrl) {
+		struct peersvr_list *tmp = calloc(1, sizeof(struct peersvr_list));
+		tmp->pmom = pmom;
+		struct peersvr_list *itr;
+		for (itr = peersvrl; itr->next; itr = itr->next)
+			;
+		itr->next = tmp;
+	} else {
+		peersvrl = calloc(1, sizeof(struct peersvr_list));
+		peersvrl->pmom = pmom;
+	}
+
+	return pmom;
+}
+
+int
+init_msi()
+{
+	int i;
+
+	peersvrl = NULL;
+
+	for (i = 0; i < get_num_servers(); i++) {
+
+		if (!strcmp(pbs_conf.psi[i].name, server_host) &&
+		    (pbs_conf.psi[i].port == pbs_server_port_dis))
+			continue;
+
+		if (create_svrmom_struct(pbs_conf.psi[i].name, pbs_conf.psi[i].port) == NULL) {
+			log_errf(-1, __func__, "Failed initialization for %s", pbs_conf.psi[i].name);
+			return -1;
+		}
+	}
+
+	return 0;
+}

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -1018,7 +1018,6 @@ setup_nodes()
 	CLEAR_HEAD(atrlist);
 
 	tfree2(&streams);
-	tfree2(&ipaddrs);
 
 	svr_totnodes = 0;
 

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -152,6 +152,7 @@ extern void free_prov_vnode(struct pbsnode *);
 extern void fail_vnode_job(struct prov_vnode_info *, int);
 extern struct prov_tracking * get_prov_record_by_vnode(char *);
 extern int parse_prov_vnode(char *,exec_vnode_listtype *);
+extern void process_IS_CMD(int);
 
 static void check_and_set_multivnode(struct pbsnode *);
 int write_single_node_mom_attr(struct pbsnode *np);
@@ -405,7 +406,7 @@ reply_hellosvr(int stream, int need_inv)
 	if ((ret = send_rpp_values(stream, 1)) != DIS_SUCCESS)
 		return ret;
 
-	if (get_msvr_mode()) {
+	if (msvr_mode()) {
 		/* In multi-server mode, server will not send clusteraddr */
 		return dis_flush(stream);
 	}
@@ -4149,7 +4150,6 @@ err:
 	free(pset);
 }
 
-
 /**
  * @brief
  * 		Input is coming from another server (MOM) over a TPP stream.
@@ -4188,7 +4188,7 @@ is_request(int stream, int version)
 	attribute		*pala;
 	resource_def		*prd;
 	resource		*prc;
-	mominfo_t		*pmom;
+	mominfo_t		*pmom = NULL;
 	mom_svrinfo_t		*psvrmom;
 	int			 s;
 	char			*val;
@@ -4300,6 +4300,8 @@ is_request(int stream, int version)
 	} else {
 		/* check that machine is known */
 		DBPRT(("%s: connect from %s\n", __func__, netaddr(addr)))
+		if ((pmom = is_peersvr(addr)) != NULL)
+			goto found;
 		if ((pmom = tfind2((u_long)stream, 0, &streams)) != NULL)
 			goto found;
 	}
@@ -5167,6 +5169,11 @@ found:
 				is_vnode_prov_done(np->nd_name);
                 }
 
+			break;
+
+		case IS_CMD:
+			DBPRT(("%s: IS_CMD\n", __func__))
+			process_IS_CMD(stream);
 			break;
 
 

--- a/src/server/node_manager.c
+++ b/src/server/node_manager.c
@@ -4300,7 +4300,7 @@ is_request(int stream, int version)
 	} else {
 		/* check that machine is known */
 		DBPRT(("%s: connect from %s\n", __func__, netaddr(addr)))
-		if ((pmom = is_peersvr(addr)) != NULL)
+		if ((pmom = get_peersvr(addr)) != NULL)
 			goto found;
 		if ((pmom = tfind2((u_long)stream, 0, &streams)) != NULL)
 			goto found;

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1381,6 +1381,13 @@ try_db_again:
 		exit(0);
 	}
 
+	tfree2(&ipaddrs);
+	if (init_msi() != 0) {
+		fprintf(stderr, "Failed to initialize peer servers\n");
+		stop_db();
+		return (3);
+	}
+
 	if (pbsd_init(server_init_type) != 0) {
 		log_err(-1, msg_daemonname, "pbsd_init failed");
 		pbs_python_ext_quick_shutdown_interpreter();

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -1061,10 +1061,9 @@ dispatch_request(int sfds, struct batch_request *request)
 static void
 log_request(struct batch_request *request, int stream)
 {
-	sprintf(log_buffer, msg_request, request->rq_type, request->rq_user,
-		request->rq_host, stream);
-	log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_REQUEST, LOG_DEBUG, "",
-		log_buffer);
+	log_eventf(PBSEVENT_DEBUG2, PBS_EVENTCLASS_REQUEST, LOG_DEBUG, "",
+		   msg_request, request->rq_type, request->rq_user,
+		   request->rq_host, stream);
 }
 
 /**
@@ -1126,7 +1125,7 @@ process_IS_CMD(int stream)
 	log_request(request, stream);
 
 #ifndef PBS_MOM
-	if (is_peersvr(addr)) {
+	if (get_peersvr(addr)) {
 		/* request came from another server */
 		request->rq_perm = ATR_DFLAG_USRD | ATR_DFLAG_USWR |
 				   ATR_DFLAG_OPRD | ATR_DFLAG_OPWR |

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -1049,6 +1049,98 @@ dispatch_request(int sfds, struct batch_request *request)
 
 /**
  * @brief
+ *	batch request for log
+ *
+ * @param[in] request - pointer to batch_request structure
+ * @param[in] stream  - connection stream
+ *
+ * @return Void
+ *
+ */
+
+static void
+log_request(struct batch_request *request, int stream)
+{
+	sprintf(log_buffer, msg_request, request->rq_type, request->rq_user,
+		request->rq_host, stream);
+	log_event(PBSEVENT_DEBUG2, PBS_EVENTCLASS_REQUEST, LOG_DEBUG, "",
+		log_buffer);
+}
+
+/**
+ * @brief
+ *  process_IS_CMD: Create batch request on received IS_CMD message
+ *                   and dispatch request.
+ *
+ *  @param[in] - stream -  connection stream.
+ *
+ *  @return void
+ *
+ */
+void
+process_IS_CMD(int stream)
+{
+	int rc;
+	struct batch_request *request;
+	struct	sockaddr_in	*addr;
+	char *msgid = NULL;
+
+	addr = tpp_getaddr(stream);
+	if (addr == NULL) {
+		sprintf(log_buffer, "Sender unknown");
+		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_REQUEST, LOG_DEBUG, "?", log_buffer);
+		return;
+	}
+
+	/* in case of IS_CMD there is a unique id passed with each command,
+	 * which we need to send back with the reply so server can
+	 * match the replies to the requests
+	 */
+	msgid = disrst(stream, &rc);
+	if (!msgid || rc) {
+		close(stream);
+		return;
+	}
+
+	request = alloc_br(0); /* freed when reply sent */
+	if (!request) {
+		close(stream);
+		if (msgid)
+			free(msgid);
+		return;
+	}
+
+	request->rq_conn = stream;
+	strcpy(request->rq_host, netaddr(addr));
+	request->rq_fromsvr = 1;
+	request->prot = PROT_TPP;
+	request->tppcmd_msgid = msgid;
+
+	rc = dis_request_read(stream, request);
+	if (rc != 0) {
+		close(stream);
+		free_br(request);
+		return;
+	}
+
+	log_request(request, stream);
+
+#ifndef PBS_MOM
+	if (is_peersvr(addr)) {
+		/* request came from another server */
+		request->rq_perm = ATR_DFLAG_USRD | ATR_DFLAG_USWR |
+				   ATR_DFLAG_OPRD | ATR_DFLAG_OPWR |
+				   ATR_DFLAG_MGRD | ATR_DFLAG_MGWR |
+				   ATR_DFLAG_SvWR;
+
+	}
+#endif
+
+	dispatch_request(stream, request);
+}
+
+/**
+ * @brief
  * 		close_client - close a connection to a client, also "inactivate"
  *		  any outstanding batch requests on that connection.
  *

--- a/src/server/req_manager.c
+++ b/src/server/req_manager.c
@@ -2516,7 +2516,7 @@ mgr_node_unset(struct batch_request *preq)
  * @retval	PBS error	- error
  */
 
-static int
+int
 make_host_addresses_list(char *phost, u_long **pul)
 {
 	int		i;
@@ -2956,7 +2956,7 @@ create_pbs_node2(char *objname, svrattrl *plist, int perms, int *bad, struct pbs
 
 		nport = pnode->nd_attr[(int)ND_ATR_Port].at_val.at_long;
 
-		if ((pmom = create_svrmom_entry(phost, nport, pul)) == NULL) {
+		if ((pmom = create_svrmom_entry(phost, nport, pul, 0)) == NULL) {
 			effective_node_delete(pnode);
 			return (PBSE_SYSTEM);
 		}

--- a/src/server/req_movejob.c
+++ b/src/server/req_movejob.c
@@ -167,7 +167,16 @@ req_movejob(struct batch_request *req)
 			reply_ack(req);
 			break;
 		case -1:
+		case -2:
 		case 1:			/* fail */
+			if (jobp && req && req->rq_type == PBS_BATCH_MoveJob &&
+			    req->rq_ind.rq_move.run_exec_vnode) {
+				int newstate;
+				int newsub;
+				/* force re-eval of job state out of Transit */
+				svr_evaljobstate(jobp, &newstate, &newsub, 1);
+				svr_setjobstate(jobp, newstate, newsub);
+			}
 			if (jobp->ji_clterrmsg)
 				reply_text(req, pbs_errno, jobp->ji_clterrmsg);
 			else

--- a/src/server/req_movejob.c
+++ b/src/server/req_movejob.c
@@ -169,8 +169,7 @@ req_movejob(struct batch_request *req)
 		case -1:
 		case -2:
 		case 1:			/* fail */
-			if (jobp && req && req->rq_type == PBS_BATCH_MoveJob &&
-			    req->rq_ind.rq_move.run_exec_vnode) {
+			if (jobp) {
 				int newstate;
 				int newsub;
 				/* force re-eval of job state out of Transit */

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -307,10 +307,6 @@ void
 move_and_runjob(struct batch_request *preq, job *pjob)
 {
 	char *dest;
-	//int sock;
-	//int conn = -1;
-	pbs_net_t	 hostaddr;
-	unsigned int	 port = pbs_server_port_dis;
 
 	dest = strdup(preq->rq_ind.rq_run.rq_destin);
 	free(preq->rq_ind.rq_run.rq_destin);
@@ -319,29 +315,6 @@ move_and_runjob(struct batch_request *preq, job *pjob)
 	strcpy(preq->rq_ind.rq_move.rq_jid, pjob->ji_qs.ji_jobid);
 	sprintf(preq->rq_ind.rq_move.rq_destin, "%s@%s", pjob->ji_qs.ji_queue, preq->rq_extend);
 	preq->rq_ind.rq_move.run_exec_vnode = dest;
-
-	get_hostaddr_port_from_svr(preq->rq_ind.rq_move.rq_destin, &hostaddr, &port);
-
-	/*sock = get_peer_server_sock(hostaddr, port);
-	if (sock != -1 && !is_socket_up(sock)) {
-		log_eventf(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO,
-				__func__, "Error from peer server socket fd, "
-				"closing connection: %d", sock);
-		close_conn(sock);
-		sock = -1;
-	}
-
-	if (sock == -1) {
-		if ((conn = connect_2_svr(hostaddr, port)) == -1) {
-			req_reject(SEND_JOB_FATAL, 0, preq);
-			return;
-		}
-
-		log_eventf(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO,
-			   __func__, "New Peer Server fd of server: %s is :%d",
-			   preq->rq_extend, conn);
-		set_peer_server_conn(conn);
-	}*/
 
 	req_movejob(preq);
 }

--- a/src/server/req_runjob.c
+++ b/src/server/req_runjob.c
@@ -307,8 +307,8 @@ void
 move_and_runjob(struct batch_request *preq, job *pjob)
 {
 	char *dest;
-	int sock;
-	int conn = -1;
+	//int sock;
+	//int conn = -1;
 	pbs_net_t	 hostaddr;
 	unsigned int	 port = pbs_server_port_dis;
 
@@ -322,7 +322,7 @@ move_and_runjob(struct batch_request *preq, job *pjob)
 
 	get_hostaddr_port_from_svr(preq->rq_ind.rq_move.rq_destin, &hostaddr, &port);
 
-	sock = get_peer_server_sock(hostaddr, port);
+	/*sock = get_peer_server_sock(hostaddr, port);
 	if (sock != -1 && !is_socket_up(sock)) {
 		log_eventf(PBSEVENT_SYSTEM, PBS_EVENTCLASS_SERVER, LOG_INFO,
 				__func__, "Error from peer server socket fd, "
@@ -341,7 +341,7 @@ move_and_runjob(struct batch_request *preq, job *pjob)
 			   __func__, "New Peer Server fd of server: %s is :%d",
 			   preq->rq_extend, conn);
 		set_peer_server_conn(conn);
-	}
+	}*/
 
 	req_movejob(preq);
 }

--- a/src/server/svr_connect.c
+++ b/src/server/svr_connect.c
@@ -135,12 +135,8 @@ svr_connect(pbs_net_t hostaddr, unsigned int port, void (*func)(int), enum conn_
 	if ((hostaddr == pbs_server_addr) && (port == pbs_server_port_dis))
 		return (PBS_LOCAL_CONNECTION);	/* special value for local */
 
-	/*if ((sock = get_peer_server_sock(hostaddr, port)) != -1)
-		return sock;
-	*/
-
 	pmom = tfind2((unsigned long)hostaddr, port, &ipaddrs);
-	if ((pmom != NULL) && (port == pmom->mi_port)) {
+	if (pmom && (port == pmom->mi_port)) {
 		if ((((mom_svrinfo_t *)(pmom->mi_data))->msr_state & INUSE_DOWN)
 							&& (open_momstream(pmom) < 0)) {
 			pbs_errno = PBSE_NORELYMOM;
@@ -261,10 +257,6 @@ svr_disconnect_with_wait_option(int sock, int wait)
 
 	if (sock < 0 || sock >= PBS_LOCAL_CONNECTION)
 		return ;
-
-	/*if (get_peer_server_sock(get_connectaddr(sock), get_connectport(sock)) != -1)
-		return;
-	*/
 
 	if (pbs_client_thread_lock_connection(sock) != 0)
 		return;

--- a/src/server/svr_connect.c
+++ b/src/server/svr_connect.c
@@ -135,8 +135,9 @@ svr_connect(pbs_net_t hostaddr, unsigned int port, void (*func)(int), enum conn_
 	if ((hostaddr == pbs_server_addr) && (port == pbs_server_port_dis))
 		return (PBS_LOCAL_CONNECTION);	/* special value for local */
 
-	if ((sock = get_peer_server_sock(hostaddr, port)) != -1)
+	/*if ((sock = get_peer_server_sock(hostaddr, port)) != -1)
 		return sock;
+	*/
 
 	pmom = tfind2((unsigned long)hostaddr, port, &ipaddrs);
 	if ((pmom != NULL) && (port == pmom->mi_port)) {
@@ -261,8 +262,9 @@ svr_disconnect_with_wait_option(int sock, int wait)
 	if (sock < 0 || sock >= PBS_LOCAL_CONNECTION)
 		return ;
 
-	if (get_peer_server_sock(get_connectaddr(sock), get_connectport(sock)) != -1)
+	/*if (get_peer_server_sock(get_connectaddr(sock), get_connectport(sock)) != -1)
 		return;
+	*/
 
 	if (pbs_client_thread_lock_connection(sock) != 0)
 		return;


### PR DESCRIPTION
* Using TPP for inter-server job transfer in case of multi-server.
* Failures in move + run path, job seems stuck in T state, Protocol error in server logs
Why? As multiple forked processes trying to read the reply from peer server using the same FD, they might be reading the wrong values.
Fix: Commenting out the code for reusing FD. This will be cleaned up when we make use of send_job_exec path.

* Resources Aggregation garbles values and qstat -Bf intermittent failures

Testing:
[accounting_records_1000_jobs.txt](https://github.com/subhasisb/openpbs/files/5070702/accounting_records_1000_jobs.txt)

