### PR TITLE
pbs_sched does not come up if fqdn and short hostname are mixed in conf file

### DIFF
--- a/src/scheduler/misc.c
+++ b/src/scheduler/misc.c
@@ -1645,9 +1645,23 @@ get_svr_index(char *svrname)
 {
 	int i;
 	int svrindex = -1;
+	int comp_len = 0;
+	int l1 = strlen(svrname);
 
 	for (i = 0; i < get_num_servers(); i++) {
-		if (strcmp(pbs_conf.psi[i].name, svrname) == 0) {
+		int l2 = strlen(pbs_conf.psi[i].name);
+		if (l1 == l2)
+			comp_len = l1;
+		else if (l1 < l2) 
+			comp_len = l1;
+		else
+			comp_len = l2;
+
+		/* Always good to compare shortname if both fqdn and short hostname are used .
+		 * It is because we can have short name in PBS_SERVER and fqdn in
+		 * PBS_SERVER_INSTANCES and vice versa
+		 */
+		if (strncmp(pbs_conf.psi[i].name, svrname, comp_len) == 0) {
 			svrindex = i;
 			break;
 		}


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
pbs_sched does not come up if fqdn is used in PBS_SERVER_INSTANCES and short hostname is used in PBS_SERVER and vice versa in the pbs.conf file.

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
If Server connects to Scheduler, the server index is calculated using the function get_svr_index(). In this function we compare the given server name with PBS_SERVER. If one of them is fqdn and the other is short hostname the check fails and this function returns -1 as server index. So sched complains "Unknown Server" and does not come up.

Solution is always compare short hostname of the server if fqdn/short hostname are mixed in the above conf variables, If not do a full compare.

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Attached are the UNIT testing logs.
[fqdn_issue.txt](https://github.com/subhasisb/openpbs/files/5067472/fqdn_issue.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
