### PR TITLE
Scheduler bug fixes to handle various Admin configurations for Multi-Server

### DIFF
--- a/src/scheduler/misc.h
+++ b/src/scheduler/misc.h
@@ -289,7 +289,7 @@ add_str_to_unique_array(char ***str_arr, char *str);
  */
 void free_ptr_array (void *inp);
 
-int get_svr_index(char *svrname);
+int get_svr_index(char *svrname, int port);
 
 #ifdef	__cplusplus
 }


### PR DESCRIPTION


<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->

Scheduler goes to infinite loop for the following Admin configuration/scenario.
**Configuration :** Multiple Servers with the same server name but with different port numbers configured in PBS_SERER_INSTANCES

Found some other valid configurations for which the above issue can happen. For example

- Unknown Server which is not part of PBS_SERVER_INSTANCES connecting to pbs_sched. Scheduler should not go down in this case.
- Multiple Servers with the same port but one server name is a substring of another server name
- FQDN in PBS_SERVER_INSTANCES but short server name in PBS_SERVER
- Short server name in PBS_SERVER_INSTANCES but fqdn in PBS_SERVER
- Duplicate entry in PBS_SERVER_INSTANCES
- Multiple Servers with the same port but one server name is a substring of another server name. Here the server names can either be lower or upper case.
- FQDN in PBS_SERVER_INSTANCES but short server name in PBS_SERVER. FQDN and server name can be in either lower or upper case
- Short server name in PBS_SERVER_INSTANCES but fqdn in PBS_SERVER. FQDN and server name can be in either lower or upper case

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->

- get_svr_index() used to provide a server index given a server name whereas it has to take care of port number during comparison.
- Also it has to take care of mixed combinations of FQDN/short server names.
- Also handled the case if an unknown server comes up

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Attached are the UNIT testing logs. 
[Admin_Confs_test.txt](https://github.com/subhasisb/openpbs/files/5089955/Admin_Confs_test.txt)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
