### PR TITLE
Schedule when all servers are ready + single mgr command for all servers + misc enhancements

### DIFF
--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -176,6 +176,8 @@ static char *entlim_attrs[] = {
 	NULL		/* keep as last one please */
 };
 
+int num_connected_svrs = 0;
+
 /* Hook-related variables and functions */
 
 static char *hook_tempfile = NULL;  /* a temporary file in PBS_HOOK_WORKDIR */
@@ -1613,6 +1615,19 @@ make_connection(char *name)
 	else
 		PSTDERR1("qmgr: cannot connect to server %s\n", name)
 
+	if (getenv(MULTI_SERVER)) {
+		int i;
+		svr_conn_t *svr_connections = get_conn_servers();
+		for (i = 0; i < get_num_servers(); i++) {
+			if (svr_connections[i].state != SVR_CONN_STATE_CONNECTED) {
+				PSTDERR1("qmgr: cannot connect to server %s\n", pbs_conf.psi[i].name)
+			}
+			else
+				num_connected_svrs++;
+			
+		}
+	}
+
 	return svr;
 }
 
@@ -1649,7 +1664,7 @@ connect_servers(struct objname *server_names, int numservers)
 		/* if numservers == -1 (all servers) the var i will never equal zero */
 		for (i = numservers; i != 0 && cur_obj != NULL; i--, cur_obj=cur_obj->next) {
 			nservers++;
-			if ((cur_svr = make_connection(cur_obj->svr_name)) ==NULL) {
+			if ((cur_svr = make_connection(cur_obj->svr_name)) == NULL) {
 				nservers--;
 				error = TRUE;
 			}
@@ -2944,6 +2959,12 @@ execute(int aopt, int oper, int type, char *names, struct attropl *attribs)
 					else if (pbs_errno == PBSE_HOOKERROR) {
 						pstderr("qmgr: hook error returned from server\n");
 					}
+					else if ((num_connected_svrs == get_num_servers()) && (pbs_errno == PBSE_NOSERVER))
+						/*
+						 * Assume that all servers are up when qmgr started, but by the time we reach here if one of IFLs
+						 * gvies the return code PBSE_NOSERVER then only we need to display the following message.
+						 */
+						pstderr("Requested operation is partially successful. Please run this command again\n");
 					else
 						if (pbs_errno != 0)  /* 0 happens with hooks if no hooks found */
 							PSTDERR1("qmgr: Error (%d) returned from server\n", pbs_errno)

--- a/src/cmds/qmgr.c
+++ b/src/cmds/qmgr.c
@@ -2959,12 +2959,12 @@ execute(int aopt, int oper, int type, char *names, struct attropl *attribs)
 					else if (pbs_errno == PBSE_HOOKERROR) {
 						pstderr("qmgr: hook error returned from server\n");
 					}
-					else if ((num_connected_svrs == get_num_servers()) && (pbs_errno == PBSE_NOSERVER))
+					else if ((pbs_errno == PBSE_NOSERVER) && (num_connected_svrs == get_num_servers()))
 						/*
 						 * Assume that all servers are up when qmgr started, but by the time we reach here if one of IFLs
 						 * gvies the return code PBSE_NOSERVER then only we need to display the following message.
 						 */
-						pstderr("Requested operation is partially successful. Please run this command again\n");
+						pstderr("At least one of the servers is down, please run this command again\n");
 					else
 						if (pbs_errno != 0)  /* 0 happens with hooks if no hooks found */
 							PSTDERR1("qmgr: Error (%d) returned from server\n", pbs_errno)

--- a/src/cmds/qstat.c
+++ b/src/cmds/qstat.c
@@ -2825,6 +2825,8 @@ qstat -B [-f] [-F format] [-D delim] [ server_name... ]\n";
 
 		strcpy(operand, argv[optind]);
 		tcl_addarg(ops, operand);
+		show_svr_inst_fail();
+
 		switch (mode) {
 
 			case JOBS:      /* get status of batch jobs */
@@ -2935,8 +2937,6 @@ job_no_args:
 					any_failed = connect;
 					break;
 				}
-
-				show_svr_inst_fail();
 
 				if (strcmp(pbs_server, server_old) != 0) {
 					/* changing to a different server */
@@ -3122,8 +3122,6 @@ que_no_args:
 					break;
 				}
 
-				show_svr_inst_fail();
-
 				p_status = pbs_statque(connect, queue_name_out, NULL, "full");
 				if (p_status == NULL) {
 					if (pbs_errno && (pbs_errno != PBSE_NOSERVER)) {
@@ -3172,8 +3170,6 @@ svr_no_args:
 					any_failed = connect;
 					break;
 				}
-
-				show_svr_inst_fail();
 
 				p_status = pbs_statserver(connect, NULL, "full");
 				if (p_status == NULL) {

--- a/src/include/pbs_ecl.h
+++ b/src/include/pbs_ecl.h
@@ -69,6 +69,8 @@ extern int   ecl_svr_attr_size;
 extern int   ecl_sched_attr_size;
 
 void set_no_attribute_verification(void);
+int pbs_verify_attributes_wrapper(int batch_request,
+	int parent_object, int cmd, struct attropl *attribute_list);
 
 extern int (*pfn_pbs_verify_attributes)(int connect, int batch_request,
 	int parent_object,  int command, struct attropl * attribute_list);

--- a/src/include/pbs_ifl.h
+++ b/src/include/pbs_ifl.h
@@ -578,6 +578,7 @@ typedef struct svr_conn {
 	char svr_id[MAX_SVR_ID];    	/* svr_id of the form server_name:port */
 	char name[PBS_MAXHOSTNAME];	/* server name */
 	int port;						/* server port */
+	int from_sched;					/* flag to indicate whether this conn is from sched or not */
 } svr_conn_t;
 
 /* Resource Reservation Information */

--- a/src/lib/Libecl/ecl_verify_object_name.c
+++ b/src/lib/Libecl/ecl_verify_object_name.c
@@ -56,6 +56,7 @@
 #include "pbs_ecl.h"
 #include "pbs_error.h"
 #include "pbs_nodes.h"
+#include "libpbs.h"
 
 /**
  * @brief
@@ -163,3 +164,55 @@ pbs_verify_object_name(int type, char *name)
 
 	return 0;
 }
+
+/**
+ * @brief
+ *	Wrapper function for pbs_verify_attributes. Even if one server is down it contacts another
+ *	server for the verification of attributes.
+ *
+ * @see verify_attributes
+ *
+ * @param[in]	batch_request	-	Batch Request Type
+ * @param[in]	parent_object	-	Parent Object Type
+ * @param[in]	cmd		-	Command Type
+ * @param[in]	attribute_list	-	list of attributes
+ *
+ * @return	int
+ * @retval 	0 - No failed attributes
+ * @retval 	+n - Number of failed attributes (pbs_errno set to last error)
+ * @retval 	-1 - System error verifying attributes (pbs_errno is set)
+ *
+ * @par		Side effects:
+ *		Modifies the TLS data for this thread\n
+ *		pbs_errno is set on encourtering error
+ *
+ * @par MT-safe: Yes
+ */
+int
+pbs_verify_attributes_wrapper(int batch_request,int parent_object, int cmd, struct attropl *attribute_list)
+{
+	int i;
+	int attrs_verified = 0;
+	svr_conn_t *svr_connections = get_conn_servers();
+	int num_cfg_svrs = get_num_servers();
+
+	if (!svr_connections)
+		return (pbs_errno = PBSE_NOSERVER);
+
+	for (i = 0; !(attrs_verified) && i < num_cfg_svrs; i++) {
+		/* now verify the attributes, if verification is enabled */
+		if ((pbs_verify_attributes(svr_connections[i].sd, batch_request, parent_object, cmd, attribute_list)))
+			continue;
+		else {
+			attrs_verified = 1;
+			break;
+		}
+	}
+
+	if (i == num_cfg_svrs)
+		return -1;
+	else
+		return 0;
+	
+}
+

--- a/src/lib/Libifl/int_manager.c
+++ b/src/lib/Libifl/int_manager.c
@@ -74,7 +74,14 @@ PBSD_manager(int c, int function, int command, int objtype, char *objname, struc
 {
 	int i;
 	struct batch_reply *reply;
-	int rc;
+	int rc = 0;
+	int agg_rc = 0;
+	int attrs_verified = 0;
+	svr_conn_t *svr_connections = get_conn_servers();
+	int num_cfg_svrs = get_num_servers();
+
+	if (!svr_connections)
+		return PBSE_NOSERVER;
 
 	/* initialize the thread context data, if not initialized */
 	if (pbs_client_thread_init_thread_context() != 0)
@@ -85,32 +92,57 @@ PBSD_manager(int c, int function, int command, int objtype, char *objname, struc
 		if (pbs_verify_object_name(objtype, objname) != 0)
 			return pbs_errno;
 
-	/* now verify the attributes, if verification is enabled */
-	if ((pbs_verify_attributes(c, function, objtype,
-		command, aoplp)) != 0)
-		return pbs_errno;
 
-	/* lock pthread mutex here for this connection */
-	/* blocking call, waits for mutex release */
-	if (pbs_client_thread_lock_connection(c) != 0)
-		return pbs_errno;
-
-	/* send the manage request */
-	i = PBSD_mgr_put(c, function, command, objtype, objname, aoplp, extend, PROT_TCP, NULL);
-	if (i) {
-		(void)pbs_client_thread_unlock_connection(c);
-		return i;
+	for (i = 0; !(attrs_verified) && i < num_cfg_svrs; i++) {
+		/* now verify the attributes, if verification is enabled */
+		if ((pbs_verify_attributes(svr_connections[i].sd, function, objtype, command, aoplp)))
+			continue;
+		else {
+			attrs_verified = 1;
+			break;
+		}
 	}
 
-	/* read reply from stream into presentation element */
-	reply = PBSD_rdrpy(c);
-	PBSD_FreeReply(reply);
-
-	rc = get_conn_errno(c);
-
-	/* unlock the thread lock and update the thread context data */
-	if (pbs_client_thread_unlock_connection(c) != 0)
+	if (i == num_cfg_svrs)
 		return pbs_errno;
 
-	return rc;
+	for (i = 0; i < num_cfg_svrs; i++) {
+		if (svr_connections[i].state != SVR_CONN_STATE_CONNECTED) {
+			if (svr_connections[i].from_sched)
+				return (pbs_errno = PBSE_NOSERVER);
+			else {
+				pbs_errno = PBSE_NOSERVER;
+				agg_rc = pbs_errno;
+				continue;
+			}
+		}
+
+		c = svr_connections[i].sd;
+
+		/* lock pthread mutex here for this connection */
+		/* blocking call, waits for mutex release */
+		if (pbs_client_thread_lock_connection(c) != 0)
+			return pbs_errno;
+
+		/* send the manage request */
+		rc = PBSD_mgr_put(c, function, command, objtype, objname, aoplp, extend, PROT_TCP, NULL);
+		if (rc) {
+			pbs_client_thread_unlock_connection(c);
+			return rc;
+		}
+
+		/* read reply from stream into presentation element */
+		reply = PBSD_rdrpy(c);
+		PBSD_FreeReply(reply);
+
+		rc = get_conn_errno(c);
+		if (rc != 0)
+			agg_rc = rc;
+
+		/* unlock the thread lock and update the thread context data */
+		if (pbs_client_thread_unlock_connection(c) != 0)
+			return pbs_errno;
+	}
+
+	return (pbs_errno = agg_rc);
 }

--- a/src/lib/Libifl/pbsD_connect.c
+++ b/src/lib/Libifl/pbsD_connect.c
@@ -497,6 +497,7 @@ connect_to_servers(char *server_name, uint port, char *extend_data)
 {
 	int i = 0;
 	int fd = -1;
+	int start_fd = -1;
 	int start = -1;
 	int multi_flag = 0;
 	int num_conf_servers = get_num_servers();
@@ -526,6 +527,9 @@ connect_to_servers(char *server_name, uint port, char *extend_data)
 	i = start;
 	do {
 		fd = connect_to_server(i, svr_connections, extend_data);
+		if (start_fd == -1 && fd != -1)
+			start_fd = fd;
+
 		if (svr_connections[i].state == SVR_CONN_STATE_CONNECTED && !multi_flag)
 			break;
 
@@ -534,7 +538,7 @@ connect_to_servers(char *server_name, uint port, char *extend_data)
 			i = 0;
 	} while (i != start);
 
-	return fd;
+	return start_fd;
 }
 
 /**

--- a/src/lib/Libifl/pbsD_statsched.c
+++ b/src/lib/Libifl/pbsD_statsched.c
@@ -67,5 +67,58 @@
 struct batch_status *
 __pbs_statsched(int c, struct attrl *attrib, char *extend)
 {
-	return PBSD_status_random(c, PBS_BATCH_StatusSched, "", attrib, extend, MGR_OBJ_SCHED);
+	struct batch_status *ret = NULL;
+	int attrs_verified = 0;
+	svr_conn_t *svr_connections = get_conn_servers();
+	int num_cfg_svrs = get_num_servers();
+	int i;
+
+	if (!svr_connections)
+		return NULL;
+
+	/* initialize the thread context data, if not already initialized */
+	if (pbs_client_thread_init_thread_context() != 0)
+		return NULL;
+
+	for (i = 0; !(attrs_verified) && i < num_cfg_svrs; i++) {
+		/* now verify the attributes, if verification is enabled */
+		if ((pbs_verify_attributes(svr_connections[i].sd, PBS_BATCH_StatusSched, MGR_OBJ_SCHED, MGR_CMD_NONE, (struct attropl *) attrib)))
+			continue;
+		else {
+			attrs_verified = 1;
+			break;
+		}
+	}
+
+	if (i == num_cfg_svrs)
+		return NULL;
+
+	for (i = 0; i < num_cfg_svrs; i++) {
+		if (svr_connections[i].state != SVR_CONN_STATE_CONNECTED) {
+			if (svr_connections[i].from_sched)
+				return NULL;
+			continue;
+		}
+
+		c = svr_connections[i].sd;
+
+		/* lock pthread mutex here for this connection */
+		/* blocking call, waits for mutex release */
+		if (pbs_client_thread_lock_connection(c) != 0)
+			return NULL;
+
+		ret = PBSD_status(c, -1, PBS_BATCH_StatusSched, "", attrib, extend);
+
+		if (ret == NULL) {
+			pbs_client_thread_unlock_connection(c);
+			continue;
+		} else {
+			/* unlock the thread lock and update the thread context data */
+			if (pbs_client_thread_unlock_connection(c) != 0)
+				return NULL;
+			return ret;
+		}
+	}
+
+	return ret;
 }

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2893,9 +2893,8 @@ cleanup:
  *
  */
 int
-update_svr_schedobj(int connector, int cmd, int alarm_time)
+update_svr_schedobj(int connector, int cmd)
 {
-	char tempstr[128];
 	struct attropl*attribs, *patt;
 
 	if (cmd == SCH_ERROR || connector < 0)
@@ -2906,7 +2905,7 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 	}
 
 	/* update the sched with new values */
-	attribs = calloc(2, sizeof(struct attropl));
+	attribs = calloc(1, sizeof(struct attropl));
 	if (attribs == NULL) {
 		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SCHED, LOG_INFO, __func__, MEM_ERR_MSG);
 		return 0;
@@ -2915,13 +2914,6 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 	patt = attribs;
 	patt->name = ATTR_version;
 	patt->value = PBS_VERSION;
-	if (alarm_time) {
-		patt->next = patt + 1;
-		patt++;
-		patt->name = ATTR_sched_cycle_len;
-		snprintf(tempstr, sizeof(tempstr), "%d", alarm_time);
-		patt->value = tempstr;
-	}
 	patt->next = NULL;
 
 	pbs_manager(connector, MGR_CMD_SET, MGR_OBJ_SCHED, sc_name, attribs, NULL);

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2875,55 +2875,6 @@ cleanup:
 
 /**
  * @brief
- *	Updates a set of attribute values of scheduler to the server and also does a status of this scheduler
- *	on server and fetches the updates of its attributes.
- *
- * @param[in] connector - socket descriptor to server
- * @param[in] cmd     - scheduler command
- * @param[in] alarm_time  - value to be updated for scheduler cycle length.
- *
- *
- * @retval Error code
- * @return 0 - Failure
- * @return 1 - Success
- *
- * @par Side Effects:
- *	None
- *
- *
- */
-int
-update_svr_schedobj(int connector, int cmd)
-{
-	struct attropl*attribs, *patt;
-
-	if (cmd == SCH_ERROR || connector < 0)
-		return 1;
-
-	if (!set_validate_sched_attrs(connector)) {
-		return 0;
-	}
-
-	/* update the sched with new values */
-	attribs = calloc(1, sizeof(struct attropl));
-	if (attribs == NULL) {
-		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SCHED, LOG_INFO, __func__, MEM_ERR_MSG);
-		return 0;
-	}
-
-	patt = attribs;
-	patt->name = ATTR_version;
-	patt->value = PBS_VERSION;
-	patt->next = NULL;
-
-	pbs_manager(connector, MGR_CMD_SET, MGR_OBJ_SCHED, sc_name, attribs, NULL);
-
-	free(attribs);
-	return 1;
-}
-
-/**
- * @brief
  *	Set and validate the sched object attributes queried from Server
  *
  * @param[in] connector - socket descriptor to server

--- a/src/scheduler/fifo.c
+++ b/src/scheduler/fifo.c
@@ -2896,10 +2896,7 @@ int
 update_svr_schedobj(int connector, int cmd, int alarm_time)
 {
 	char tempstr[128];
-	char port_str[MAX_INT_LEN];
 	struct attropl*attribs, *patt;
-	char sched_host[PBS_MAXHOSTNAME + 1];
-
 
 	if (cmd == SCH_ERROR || connector < 0)
 		return 1;
@@ -2909,29 +2906,13 @@ update_svr_schedobj(int connector, int cmd, int alarm_time)
 	}
 
 	/* update the sched with new values */
-	attribs = calloc(4, sizeof(struct attropl));
+	attribs = calloc(2, sizeof(struct attropl));
 	if (attribs == NULL) {
 		log_event(PBSEVENT_DEBUG, PBS_EVENTCLASS_SCHED, LOG_INFO, __func__, MEM_ERR_MSG);
 		return 0;
 	}
 
-	if ((gethostname(sched_host, (sizeof(sched_host) - 1)) == -1) ||
-		(get_fullhostname(sched_host, sched_host, (sizeof(sched_host) - 1)) == -1)) {
-		log_err(-1, __func__, "Unable to get my host name");
-		free(attribs);
-		return 0;
-	}
-
 	patt = attribs;
-	patt->name = ATTR_SchedHost;
-	patt->value = sched_host;
-	patt->next = patt + 1;
-	patt++;
-	patt->name = ATTR_sched_port;
-	snprintf(port_str, MAX_INT_LEN, "%d", sched_port);
-	patt->value = port_str;
-	patt->next = patt + 1;
-	patt++;
 	patt->name = ATTR_version;
 	patt->value = PBS_VERSION;
 	if (alarm_time) {

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -228,7 +228,6 @@ int main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rer
  */
 int scheduler_simulation_task(int pbs_sd, int debug);
 
-int update_svr_schedobj(int connector, int cmd);
 
 int set_validate_sched_attrs(int connector);
 

--- a/src/scheduler/fifo.h
+++ b/src/scheduler/fifo.h
@@ -228,7 +228,7 @@ int main_sched_loop(status *policy, int sd, server_info *sinfo, schd_error **rer
  */
 int scheduler_simulation_task(int pbs_sd, int debug);
 
-int update_svr_schedobj(int connector, int cmd, int alarm_time);
+int update_svr_schedobj(int connector, int cmd);
 
 int set_validate_sched_attrs(int connector);
 

--- a/src/scheduler/job_info.c
+++ b/src/scheduler/job_info.c
@@ -999,7 +999,7 @@ query_jobs(status *policy, int pbs_sd, queue_info *qinfo, resource_resv **pjobs,
 	}
 
 	/* get jobs from PBS server */
-	if ((jobs = pbs_selstat(pbs_sd, &opl, attrib, "S")) == NULL) {
+	if (((jobs = pbs_selstat(pbs_sd, &opl, attrib, "S")) == NULL) || pbs_errno) {
 		if (pbs_errno > 0) {
 			errmsg = pbs_geterrmsg(pbs_sd);
 			if (errmsg == NULL)

--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -449,7 +449,7 @@ query_nodes(int pbs_sd, server_info *sinfo)
 	}
 
 	/* get nodes from all PBS servers */
-	if ((nodes = pbs_statvnode(pbs_sd, NULL, attrib, NULL)) == NULL) {
+	if (((nodes = pbs_statvnode(pbs_sd, NULL, attrib, NULL)) == NULL) || pbs_errno) {
 		err = pbs_geterrmsg(pbs_sd);
 		log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_NODE, LOG_INFO, "", "Error getting nodes: %s", err);
 		return NULL;

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -56,7 +56,6 @@
  *	badconn()
  *	server_command()
  *	engage_authentication()
- *	update_svr_schedobj()
  *	lock_out()
  *	are_we_primary()
  *	main()
@@ -1559,17 +1558,6 @@ schedule_wrapper(fd_set *read_fdset, int opt_no_restart, int *num_connected_svrs
 				break;
 			} else {
 				int sched_ret;
-				static int num_svrs_updated = 0;
-
-				if (num_svrs_updated < num_cfg_svrs) {
-					/* update sched object attributes on server */
-					if (update_svr_schedobj(ifl_sock, cmd) == 0) {
-						close_server_conn(svr_inst_idx);
-						(*num_connected_svrs)--;
-						break;
-					}
-					num_svrs_updated++;
-				}
 
 				/* Keep track of time to use in SIGSEGV handler */
 #ifdef NAS /* localmod 031 */

--- a/src/scheduler/resv_info.c
+++ b/src/scheduler/resv_info.c
@@ -105,7 +105,7 @@ stat_resvs(int pbs_sd)
 	char *errmsg;
 
 	/* get the reservation info from the PBS server */
-	if ((resvs = pbs_statresv(pbs_sd, NULL, NULL, NULL)) == NULL) {
+	if (((resvs = pbs_statresv(pbs_sd, NULL, NULL, NULL)) == NULL) || pbs_errno) {
 		if (pbs_errno) {
 			errmsg = pbs_geterrmsg(pbs_sd);
 			if (errmsg == NULL)

--- a/src/scheduler/server_info.c
+++ b/src/scheduler/server_info.c
@@ -201,7 +201,7 @@ query_server(status *pol, int pbs_sd)
 	}
 
 	/* get server information from pbs server */
-	if ((server = pbs_statserver(pbs_sd, NULL, NULL)) == NULL) {
+	if (((server = pbs_statserver(pbs_sd, NULL, NULL)) == NULL) || pbs_errno) {
 		errmsg = pbs_geterrmsg(pbs_sd);
 		if (errmsg == NULL)
 			errmsg = "";

--- a/src/server/pbsd_main.c
+++ b/src/server/pbsd_main.c
@@ -1686,12 +1686,16 @@ try_db_again:
 				if (server_init_type == RECOV_CREATE)
 					break;
 
+				if (psched->sch_attr[(int)SCHED_ATR_scheduling].at_val.at_long == 0)
+					continue;
+
 				/* if time or event says to run scheduler, do it */
 				if (psched->scheduler_sock[0] == CONN_UNKNOWN &&
 					psched->scheduler_sock[1] == CONN_UNKNOWN) {
 					connect_to_scheduler(psched);
 					continue;
 				}
+
 				/* if we have a high prio sched command, send it 1st */
 				if (psched->svr_do_sched_high != SCH_SCHEDULE_NULL)
 					schedule_high(psched);

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -861,13 +861,6 @@ req_stat_sched(struct batch_request *preq)
 			(psched != NULL);
 			psched = (pbs_sched *) GET_NEXT(psched->sc_link)
 		) {
-		if (psched == dflt_scheduler &&
-			((psched->sch_attr[(int) SCHED_ATR_SchedHost].at_flags & ATR_VFLAG_SET) == 0 ||
-			strcmp(pbs_conf.pbs_server_name, dflt_scheduler->sch_attr[SCHED_ATR_SchedHost].at_val.at_str))) {
-			req_reject(PBSE_NOSCHEDULER, 0, preq);
-			return;
-		}
-
 		rc = status_sched(psched, preq, &preply->brp_un.brp_status);
 		if (rc != 0) {
 			break;

--- a/src/server/req_stat.c
+++ b/src/server/req_stat.c
@@ -853,7 +853,6 @@ req_stat_sched(struct batch_request *preq)
 	pbs_sched *psched;
 
 	/* allocate a reply structure and a status sub-structure */
-
 	preply = &preq->rq_reply;
 	preply->brp_choice = BATCH_REPLY_CHOICE_Status;
 	CLEAR_HEAD(preply->brp_un.brp_status);
@@ -862,6 +861,13 @@ req_stat_sched(struct batch_request *preq)
 			(psched != NULL);
 			psched = (pbs_sched *) GET_NEXT(psched->sc_link)
 		) {
+		if (psched == dflt_scheduler &&
+			((psched->sch_attr[(int) SCHED_ATR_SchedHost].at_flags & ATR_VFLAG_SET) == 0 ||
+			strcmp(pbs_conf.pbs_server_name, dflt_scheduler->sch_attr[SCHED_ATR_SchedHost].at_val.at_str))) {
+			req_reject(PBSE_NOSCHEDULER, 0, preq);
+			return;
+		}
+
 		rc = status_sched(psched, preq, &preply->brp_un.brp_status);
 		if (rc != 0) {
 			break;


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
This PR consists of the following enhancements.

- qmgr/pbs_manager request should go to all servers automatically.
- Even if one of the configured servers is not available qmgr update should fail. But the stats queries should be successful when queried through external clients. But when they are called from scheduler the operation should fail.
- Server should stop contacting Scheduler when scheduling is off. This helps in not logging the following message to server logs continuously thus by filling up all the system when scheduler is gone down.
        08/25/2020 08:16:29;0001;Server@spark1;Svr;Server@spark1;Operation now in progress (115) in 
        contact_sched, Could not contact Scheduler
        08/25/2020 08:16:29;0001;Server@spark1;Svr;Server@spark1;Operation now in progress (115) in 
        contact_sched, Could not contact Scheduler
- Even default scheduler's host and port should be allowed to change by Admins. This is because only scheduler runs in Multi-Server and all other Servers should talk to the same scheduler.
- sched_host/sched_port if changed should remain persisted after server restarts. This is because Scheduler always overwrites them as part of the attribute updates when Server first contacts Scheduler. Modified this part of the code so that the changes are retained after server/s restarts.
- Similarly we should allow admin's to change sched_priv/sched_logs for default directory. This is again for the reasons mentioned above
- In fact following is recommended for Admin as a one time activity during the MultiServer setup. Set all of these values correctly so that remaining servers will connect to the same scheduler.
    qmgr -c "s sc sched_host=spark1,sched_port=15004"
    qmgr -c "s sched sched_log=/var/spool/pbs/sched_logs"
    qmgr -c "s sched sched_priv=/var/spool/pbs/sched_priv"
- Scheduling does not happen if one server goes down
  - untill all servers connected
  - if any server goes down while scheduler queries
#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
