### PR TITLE
Disable resvport authentication for non-priv containers and safe keeping test scripts

### DIFF
--- a/src/cmds/scripts/pbs_dataservice
+++ b/src/cmds/scripts/pbs_dataservice
@@ -226,9 +226,9 @@ check_status() {
 #
 oom_protect() {
 	if [ -f /proc/self/oom_score_adj ] ; then
-		echo "-1000" > /proc/self/oom_score_adj
+		echo "-1000" > /proc/self/oom_score_adj 2>/dev/null
 	elif [ -f /proc/self/oom_adj ] ; then
-		echo "-17" > /proc/self/oom_adj
+		echo "-17" > /proc/self/oom_adj 2>/dev/null
 	fi
 }
 
@@ -245,8 +245,8 @@ oom_protect() {
 #
 start_dataservice() {
 	is_systemd=0
-	systemctl --version >/dev/null 2>&1
-	if [ $? -eq 0 ] ; then
+	sc_status="$(systemctl is-system-running 2>/dev/null)"
+	if [ "x${sc_status}" == "xrunning" -o "x${sc_status}" == "xdegraded" ] ; then
 		is_systemd=1
 	fi
 

--- a/src/lib/Libnet/net_client.c
+++ b/src/lib/Libnet/net_client.c
@@ -233,7 +233,6 @@ client_to_svr_extend(pbs_net_t hostaddr, unsigned int port, int authport_flags, 
 {
 	struct sockaddr_in	remote;
 	int	sock;
-	int	local_port;
 	int	errn;
 	int	rc;
 #ifdef WIN32
@@ -249,95 +248,9 @@ client_to_svr_extend(pbs_net_t hostaddr, unsigned int port, int authport_flags, 
 	int		oflag;
 #endif
 
-
-	/*	If local privilege port requested, bind to one	*/
-	/*	Must be root privileged to do this		*/
-	local_port = authport_flags & B_RESERVED;
-
-	if (local_port) {
-#ifdef	IP_PORTRANGE_LOW
-		int			lport = IPPORT_RESERVED - 1;
-
-		sock = rresvport(&lport);
-		if (sock < 0) {
-			if (errno == EAGAIN)
-				return PBS_NET_RC_RETRY;
-			else
-				return PBS_NET_RC_FATAL;
-		}
-#else	/* IP_PORTRANGE_LOW */
-		struct sockaddr_in	local;
-		unsigned short		tryport;
-		static unsigned short	start_port = 0;
-
-		sock = socket(AF_INET, SOCK_STREAM, 0);
-		if (sock < 0) {
-			return PBS_NET_RC_FATAL;
-		}
-
-		if (start_port == 0) {	/* arbitrary start point */
-			start_port = (getpid() %(IPPORT_RESERVED/2)) +
-				IPPORT_RESERVED/2;
-		}
-		else if (--start_port < IPPORT_RESERVED/2)
-			start_port = IPPORT_RESERVED - 1;
-		tryport = start_port;
-
-		memset(&local, 0, sizeof(local));
-		local.sin_family = AF_INET;
-		if (localaddr != NULL) {
-			local.sin_addr.s_addr = inet_addr(localaddr);
-			if (local.sin_addr.s_addr == INADDR_NONE) {
-				perror("inet_addr failed");
-				return (PBS_NET_RC_FATAL);
-			}
-		} else if (pbs_conf.pbs_public_host_name) {
-			pbs_net_t public_addr;
-			public_addr = get_hostaddr(pbs_conf.pbs_public_host_name);
-			if (public_addr == (pbs_net_t)0) {
-				return (PBS_NET_RC_FATAL);
-			}
-			local.sin_addr.s_addr = htonl(public_addr);
-		}
-		for (;;) {
-
-			local.sin_port = htons(tryport);
-			if (bind(sock, (struct sockaddr *)&local,
-				sizeof(local)) == 0)
-				break;
-#ifdef WIN32
-			errno = WSAGetLastError();
-			if (errno != EADDRINUSE && errno != EADDRNOTAVAIL && errno != WSAEACCES) {
-				closesocket(sock);
-#else
-			if (errno != EADDRINUSE && errno != EADDRNOTAVAIL) {
-				close(sock);
-#endif
-				return PBS_NET_RC_FATAL;
-			}
-			else if (--tryport < (IPPORT_RESERVED/2)) {
-				tryport = IPPORT_RESERVED - 1;
-			}
-			if (tryport == start_port) {
-#ifdef WIN32
-				closesocket(sock);
-#else
-				close(sock);
-#endif
-				return PBS_NET_RC_RETRY;
-			}
-		}
-		/*
-		 ** Ensure last tryport becomes start port on next call.
-		 */
-		start_port = tryport;
-#endif	/* IP_PORTRANGE_LOW */
-	}
-	else {
-		sock = socket(AF_INET, SOCK_STREAM, 0);
-		if (sock < 0) {
-			return PBS_NET_RC_FATAL;
-		}
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0) {
+		return PBS_NET_RC_FATAL;
 	}
 
 	remote.sin_addr.s_addr = htonl(hostaddr);

--- a/src/lib/Libtpp/tpp_router.c
+++ b/src/lib/Libtpp/tpp_router.c
@@ -1291,16 +1291,6 @@ router_pkt_handler(int tfd, void *data, int len, void *c, void *extra)
 					if (data_out)
 						free(data_out);
 					return 0; /* let connection be alive, so we can send error */
-				} else {
-					/* reserved port based authentication, and is not yet authenticated, so check resv port */
-					if (tpp_transport_isresvport(tfd) != 0) {
-						snprintf(tpp_get_logbuf(), TPP_LOGBUF_SZ, "Connection from non-reserved port, rejected");
-						tpp_log_func(LOG_CRIT, NULL, tpp_get_logbuf());
-						tpp_send_ctl_msg(tfd, TPP_MSG_AUTHERR, &connected_host, &this_router->router_addr, -1, 0, tpp_get_logbuf());
-						if (data_out)
-							free(data_out);
-						return 0; /* let connection be alive, so we can send error */
-					}
 				}
 			}
 

--- a/src/lib/Libtpp/tpp_transport.c
+++ b/src/lib/Libtpp/tpp_transport.c
@@ -1296,40 +1296,6 @@ add_transport_conn(phy_conn_t *conn)
 
 		int fd = conn->sock_fd;
 
-		/* authentication */
-		if (conn->conn_params->need_resvport) {
-			int tryport;
-			int start;
-			int rc = -1;
-
-			srand(time(NULL));
-			start = (rand() % (IPPORT_RESERVED - 1)) + 1;
-			tryport = start;
-
-			while (1) {
-				struct sockaddr_in serveraddr;
-				/* bind this socket to a reserved port */
-				serveraddr.sin_family = AF_INET;
-				serveraddr.sin_addr.s_addr = INADDR_ANY;
-				serveraddr.sin_port = htons(tryport);
-				memset(&(serveraddr.sin_zero), '\0', sizeof(serveraddr.sin_zero));
-				if ((rc = tpp_sock_bind(fd, (struct sockaddr *) &serveraddr, sizeof(serveraddr))) != -1)
-					break;
-				if ((errno != EADDRINUSE) && (errno != EADDRNOTAVAIL))
-					break;
-
-				--tryport;
-				if (tryport <= 0)
-					tryport = IPPORT_RESERVED;
-				if (tryport == start)
-					break;
-			}
-			if (rc == -1) {
-				tpp_log_func(LOG_WARNING, NULL, "No reserved ports available");
-				return (-1);
-			}
-		}
-
 		conn->net_state = TPP_CONN_CONNECTING;
 		if (tpp_em_add_fd(conn->td->em_context, conn->sock_fd,
 			EM_OUT | EM_ERR | EM_HUP) == -1) {

--- a/src/resmom/mom_main.c
+++ b/src/resmom/mom_main.c
@@ -613,7 +613,7 @@ sigset_t		allsigs;
 #endif
 int			rm_errno;
 unsigned	int	reqnum = 0;		/* the packet number */
-int			port_care = 1;		/* secure connecting ports */
+int			port_care = 0;		/* secure connecting ports */
 uid_t			uid = 0;		/* uid we are running with */
 int			alarm_time = 10;	/* time before alarm */
 int                     nice_val = 0;           /* nice daemon by this much */
@@ -7092,7 +7092,7 @@ mom_over_limit(job *pjob)
 
 		at = &pjob->ji_wattr[(int)JOB_ATR_resc_used];
 		assert(at->at_type == ATR_TYPE_RESC);
-		
+
 		rd = &svr_resc_def[RESC_CPUPERCENT];
 		prescpup = find_resc_entry(at, rd);
 		if ((prescpup != NULL) &&
@@ -8534,10 +8534,7 @@ main(int argc, char *argv[])
 
 #ifdef RLIMIT_NPROC
 		(void)getrlimit64(RLIMIT_NPROC, &orig_nproc_limit); /* get for later */
-		if (setrlimit64(RLIMIT_NPROC, &rlimit) == -1) {    /* set unlimited */
-			perror(" setrlimit NPROC");
-			exit(1);
-		}
+		(void)setrlimit64(RLIMIT_NPROC, &rlimit); /* set unlimited */
 #endif	/* RLIMIT_NPROC */
 #ifdef	RLIMIT_RSS
 		(void)setrlimit64(RLIMIT_RSS  , &rlimit);
@@ -8560,10 +8557,7 @@ main(int argc, char *argv[])
 		(void)setrlimit(RLIMIT_CPU,   &rlimit);
 #ifdef RLIMIT_NPROC
 		(void)getrlimit(RLIMIT_NPROC, &orig_nproc_limit); /* get for later */
-		if (setrlimit(RLIMIT_NPROC, &rlimit) == -1) {	  /* set unlimited */
-			perror(" setrlimit NPROC");
-			exit(1);
-		}
+		(void)(setrlimit(RLIMIT_NPROC, &rlimit); /* set unlimited */
 #endif	/* RLIMIT_NPROC */
 #ifdef	RLIMIT_RSS
 		(void)setrlimit(RLIMIT_RSS  , &rlimit);

--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -633,12 +633,6 @@ accept_svr_conn(int *max_sd)
 	setsockopt(new_socket, IPPROTO_TCP, TCP_USER_TIMEOUT, (char*) &tcp_timeout, sizeof (tcp_timeout));
 #endif
 
-	if (ntohs(saddr.sin_port) >= IPPORT_RESERVED) {
-		badconn("non-reserved port");
-		close(new_socket);
-		return SCH_ERROR;
-	}
-
 	addr = (pbs_net_t)saddr.sin_addr.s_addr;
 	for (i = 0; i < numclients; i++) {
 		if (addr == okclients[i])

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -222,12 +222,6 @@ req_authenticate(conn_t *conn, struct batch_request *request)
 		}
 		cp = conn;
 	} else {
-		/* ensure resvport auth request is coming from priv port */
-		if ((conn->cn_authen & PBS_NET_CONN_FROM_PRIVIL) == 0) {
-			req_reject(PBSE_BADCRED, 0, request);
-			close_client(conn->cn_sock);
-			return;
-		}
 		cp = (conn_t *)GET_NEXT(svr_allconns);
 		for (; cp != NULL; cp = GET_NEXT(cp->cn_link)) {
 			if (request->rq_ind.rq_auth.rq_port == cp->cn_port && conn->cn_addr == cp->cn_addr) {

--- a/test-scripts/build-image.sh
+++ b/test-scripts/build-image.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+if [ "x$1" == "x" ]; then
+    echo "Usage: $0 <path/to/pbs/source/dir>"
+    exit 1
+fi
+
+if [ ! -d $1 ]; then
+    echo "$1 doesn't exists or not directory"
+    exit 1
+fi
+
+cd $1
+
+cur_dir=$(pwd)
+TMP_DIR=${TMP_DIR:-/tmp}
+
+function build_image() {
+    local _ret
+
+    cd ${cur_dir}
+    cat >${TMP_DIR}/pp_dockerfile<<__PP_DF__
+FROM centos:8 AS base
+ENV LANG=C.utf8 LC_ALL=C.utf8
+RUN set -ex \\
+    && groupadd -g 1900 tstgrp00 \\
+    && groupadd -g 1901 tstgrp01 \\
+    && groupadd -g 1902 tstgrp02 \\
+    && groupadd -g 1903 tstgrp03 \\
+    && groupadd -g 1904 tstgrp04 \\
+    && groupadd -g 1905 tstgrp05 \\
+    && groupadd -g 1906 tstgrp06 \\
+    && groupadd -g 1907 tstgrp07 \\
+    && groupadd -g 901 pbs \\
+    && groupadd -g 1146 agt \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4357 -g tstgrp00 -G tstgrp00 pbsadmin \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 9000 -g tstgrp00 -G tstgrp00 pbsbuild \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 884 -g tstgrp00 -G tstgrp00 pbsdata \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4367 -g tstgrp00 -G tstgrp00 pbsmgr \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4373 -g tstgrp00 -G tstgrp00 pbsnonroot \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4356 -g tstgrp00 -G tstgrp00 pbsoper \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4358 -g tstgrp00 -G tstgrp00 pbsother \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4371 -g tstgrp00 -G tstgrp00 pbsroot \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4355 -g tstgrp00 -G tstgrp02,tstgrp00 pbstest \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4359 -g tstgrp00 -G tstgrp00 pbsuser \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4361 -g tstgrp00 -G tstgrp01,tstgrp02,tstgrp00 pbsuser1 \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4362 -g tstgrp00 -G tstgrp01,tstgrp03,tstgrp00 pbsuser2 \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4363 -g tstgrp00 -G tstgrp01,tstgrp04,tstgrp00 pbsuser3 \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4364 -g tstgrp01 -G tstgrp04,tstgrp05,tstgrp01 pbsuser4 \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4365 -g tstgrp02 -G tstgrp04,tstgrp06,tstgrp02 pbsuser5 \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4366 -g tstgrp03 -G tstgrp04,tstgrp07,tstgrp03 pbsuser6 \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 4368 -g tstgrp01 -G tstgrp01 pbsuser7 \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 11000 -g tstgrp00 -G tstgrp00 tstusr00 \\
+    && useradd -K UMASK=0022 -m -s /bin/bash -u 11001 -g tstgrp00 -G tstgrp00 tstusr01 \\
+    && dnf install -y sudo openssh-server openssh-clients passwd which net-tools bc \\
+    && echo 'Defaults  always_set_home' > /etc/sudoers.d/pbs \\
+    && echo 'Defaults  !requiretty' >> /etc/sudoers.d/pbs \\
+    && echo 'ALL ALL=(ALL)  NOPASSWD: ALL' >> /etc/sudoers.d/pbs \\
+    && echo '' > /etc/security/limits.conf \\
+	&& rm -f /etc/security/limits.d/*.conf \\
+    && ssh-keygen -A \\
+    && /usr/sbin/sshd \\
+    && ssh-keygen -N "" -C "common-ssh-pair" -f ~/.ssh/id_rsa -t rsa -q \\
+    && cp ~/.ssh/id_rsa.pub ~/.ssh/authorized_keys \\
+    && echo 'root:pbs' | chpasswd \\
+    && for user in \$(awk -F: '/^(pbs|tst)/ {print \$1}' /etc/passwd); do \\
+        rm -rf /home/\${user}/.ssh; \\
+        cp -rfp ~/.ssh /home/\${user}/; \\
+        chown -R \${user}: /home/\${user}/.ssh; \\
+        echo "\${user}:pbs" | chpasswd; \\
+    done \\
+    && echo 'Host *' >> /etc/ssh/ssh_config \\
+    && echo '  StrictHostKeyChecking no' >> /etc/ssh/ssh_config \\
+    && echo '  ConnectionAttempts 3' >> /etc/ssh/ssh_config \\
+    && echo '  IdentityFile ~/.ssh/id_rsa' >> /etc/ssh/ssh_config \\
+    && echo '  PreferredAuthentications publickey,password' >> /etc/ssh/ssh_config \\
+    && echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config \\
+    && dnf -y clean all \\
+    && rm -rf /var/run/*.pid /run/nologin /tmp/*
+
+FROM base AS genrpm
+COPY . /pbssrc
+RUN set -ex \\
+    && cd /pbssrc \\
+    && ONLY_INSTALL_DEPS=1 /pbssrc/.travis/do.sh \\
+    && cd /pbssrc \\
+    && git clean -ffdx \\
+    && ./autogen.sh \\
+    && mkdir target \\
+    && cd target \\
+    && ../configure --enable-ptl --with-swig=/usr/local \\
+    && make dist \\
+    && mkdir -p ~/rpmbuild/SOURCES \\
+    && cp *.tar.gz ~/rpmbuild/SOURCES/ \\
+    && CFLAGS="-g -O2 -Wall -Werror" rpmbuild -ba openpbs.spec --with ptl -D "_with_swig --with-swig=/usr/local" \\
+    && mkdir -p /tmp/rpms \\
+    && cp -v ~/rpmbuild/RPMS/x86_64/*-server*.rpm /tmp/rpms \\
+    && rm -f /tmp/rpms/*-debug*
+
+FROM base
+ENV LANG=C.utf8 LC_ALL=C.utf8
+COPY --from=genrpm /tmp/rpms /tmp/rpms
+RUN set -ex \\
+    && dnf install -y /tmp/rpms/* \\
+    && rm -rf /var/spool/pbs /etc/pbs.conf* /tmp/* \\
+    && dnf -y clean all
+__PP_DF__
+
+    _cur_md5=$(md5sum ${TMP_DIR}/pp_dockerfile | awk '{ print $1 }')
+    _image_md5=$(podman inspect pbs:latest -f '{{ index .Config.Labels "pbs-md5"}}' 2>/dev/null)
+    _src_md5=$(git ls-files | xargs md5sum | md5sum | awk '{ print $1 }')
+    _isrc_md5=$(podman inspect pbs:latest -f '{{ index .Config.Labels "pbs-src-md5"}}' 2>/dev/null)
+    if [ "x${_sr_cur_md5c_md5}" == "x${_image_md5}" -a "x${_src_md5}" == "x${_isrc_md5}" ]; then
+        rm -f ${TMP_DIR}/pp_dockerfile
+        return
+    fi
+
+    podman build --force-rm --rm -f ${TMP_DIR}/pp_dockerfile -t pbs:latest --label pbs-md5=${_cur_md5} --label pbs-src-md5=${_src_md5} .
+    _ret=$?
+    rm -f ${TMP_DIR}/pp_dockerfile
+    if [ ${_ret} -ne 0 ]; then
+        echo "pbs image build failed"
+        exit 1
+    fi
+}
+
+build_image
+podman image save pbs:latest | gzip -c > pbs.tgz

--- a/test-scripts/config.json
+++ b/test-scripts/config.json
@@ -1,0 +1,24 @@
+{
+	"setups": {
+		"setup-1" : {
+			"total_num_svrs": 1,
+			"num_moms_per_host": 20,
+			"num_cpus_per_mom": 0
+		},
+		"setup-2": {
+			"total_num_svrs": 2,
+			"num_moms_per_host": 20,
+			"num_cpus_per_mom": 0
+		},
+		"setup-3": {
+			"total_num_svrs": 5,
+			"num_moms_per_host": 20,
+			"num_cpus_per_mom": 0
+		},
+		"setup-4": {
+			"total_num_svrs": 10,
+			"num_moms_per_host": 20,
+			"num_cpus_per_mom": 0
+		}
+	}
+}

--- a/test-scripts/entrypoint
+++ b/test-scripts/entrypoint
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+if [ "x$1" == "xchangesched" ]; then
+    servers="$(grep PBS_SERVER_INSTANCES /etc/pbs.conf 2>/dev/null | cut -d= -f2)"
+    if [ "x${servers}" == "x" ]; then
+        /opt/pbs/bin/qmgr -c "s s scheduling=$2"
+        exit 0
+    fi
+    for svr in ${servers//,/ }
+    do
+        PBS_SERVER_INSTANCES=${svr} /opt/pbs/bin/qmgr -c "s s scheduling=$2" &>/dev/null
+    done
+    exit 0
+fi
+
+if [ "x$1" == "xwaitsvr" ]; then
+    . /etc/pbs.conf
+    export PBS_SERVER_INSTANCES=${PBS_SERVER}:${PBS_BATCH_SERVICE_PORT}
+    while true
+    do
+        /opt/pbs/bin/qstat -Bf &>/dev/null
+        if [ $? -eq 0 ]; then
+            break
+        fi
+        sleep 5
+    done
+    _moms=$2
+    for _mom in ${_moms//,/ }
+    do
+        _name=${_mom//:*}
+        while true
+        do
+            /opt/pbs/bin/pbsnodes -v ${_name} 2>/dev/null | grep -q 'state = free' &>/dev/null
+            if [ $? -eq 0 ]; then
+                break
+            fi
+            sleep 2
+        done
+    done
+    exit 0
+fi
+
+/usr/sbin/sshd
+
+# for server: <home path> server svrno (1 - start/0 - no start sched/comm) port dbport moms cpus svrinsts?
+_phome=/var/spool/pbs
+if [ "x$1" != "xdefault" ]; then
+    _phome=$1
+fi
+
+chown root: ${_phome}
+chmod 0755 ${_phome}
+
+if [ "x$2" == "xserver" -a $# -ge 6 ]; then
+    {
+        echo PBS_SERVER=pbs-server-$3
+        echo PBS_EXEC=/opt/pbs
+        echo PBS_HOME=${_phome}/pbs-server-$3
+        echo PBS_START_SERVER=1
+        echo PBS_START_MOM=0
+        echo PBS_START_SCHED=$4
+        echo PBS_START_COMM=$4
+        echo PBS_SCP=$(which scp)
+        echo PBS_LOG_HIGHRES_TIMESTAMP=1
+        echo PBS_CORE_LIMIT=unlimited
+        echo PBS_BATCH_SERVICE_PORT=$5
+        echo PBS_BATCH_SERVICE_PORT_DIS=$5
+        echo PBS_DATA_SERVICE_PORT=$6
+        echo PBS_LEAF_ROUTERS=pbs-server-1:17001
+        if [ "x$9" != "x" ]; then
+            echo PBS_SERVER_INSTANCES=$9
+        fi
+    } > /etc/pbs.conf
+    unset _phome
+# for mom: <home path> mom momport ownserver ownserverport name svrinsts?
+elif [ "x$2" == "xmom" -a $# -ge 5 ]; then
+    _port=$3
+    {
+        echo PBS_SERVER=$4
+        echo PBS_EXEC=/opt/pbs
+        echo PBS_HOME=${_phome}/$6
+        echo PBS_START_SERVER=0
+        echo PBS_START_MOM=1
+        echo PBS_START_SCHED=0
+        echo PBS_START_COMM=0
+        echo PBS_SCP=$(which scp)
+        echo PBS_LOG_HIGHRES_TIMESTAMP=1
+        echo PBS_CORE_LIMIT=unlimited
+        echo PBS_BATCH_SERVICE_PORT=$5
+        echo PBS_BATCH_SERVICE_PORT_DIS=$5
+        echo PBS_MOM_SERVICE_PORT=${_port}
+        echo PBS_MANAGER_SERVICE_PORT=$(( _port + 1 ))
+        echo PBS_LEAF_ROUTERS=pbs-server-1:17001
+        if [ "x$7" != "x" ]; then
+            echo PBS_SERVER_INSTANCES=$7
+        fi
+    } > /etc/pbs.conf
+    unset _port _phome
+else
+    unset _phome
+    exec /bin/bash
+fi
+/opt/pbs/libexec/pbs_init.d start
+if [ "x$2" == "xserver" ]; then
+    sleep 2
+    export PBS_SERVER_INSTANCES=pbs-server-$3:$5
+    /opt/pbs/bin/qmgr -c "s sched sched_host = pbs-server-1"
+    /opt/pbs/bin/qmgr -c "s sched sched_port = 15004"
+    /opt/pbs/bin/qmgr -c 's s acl_roots = root@*'
+    /opt/pbs/bin/qmgr -c "s s flatuid = 1"
+    _moms=$7
+    _cpus=$8
+    if [ "x${_moms}" != "xnone" ]; then
+        for _mom in ${_moms//,/ }
+        do
+            _name=${_mom//:*}
+            _mom=${_mom#*:}
+            _host=${_mom//:*}
+            _mport=${_mom//*:}
+            /opt/pbs/bin/qmgr -c "c n ${_name} MoM=${_host},Port=${_mport}"
+            if [ "x${_cpus}" != "x0" ]; then
+                /opt/pbs/bin/qmgr -c "s n ${_name} resources_available.ncpus = ${_cpus}"
+            fi
+        done
+    fi
+    unset _mom _moms _cpus _name _host _mport PBS_SERVER_INSTANCES
+fi
+exec /bin/bash

--- a/test-scripts/master.py
+++ b/test-scripts/master.py
@@ -1,0 +1,250 @@
+import json
+import os
+import pathlib
+import socket
+import subprocess
+import sys
+from concurrent.futures import ProcessPoolExecutor, wait
+
+MYDIR = str(pathlib.Path(__file__).resolve().parent)
+ME = socket.getfqdn(socket.gethostname())
+
+def run_cmd(host, cmd):
+  if host != ME:
+    cmd = ['ssh', host] + cmd
+  p = subprocess.run(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+  return p.returncode == 0
+
+def copy_artifacts(host):
+  if host != ME:
+    run_cmd(host, ['mkdir', '-p', MYDIR])
+    _c = ['scp', '-p']
+    _c += [os.path.join(MYDIR, 'pbs.tgz')]
+    _c += [os.path.join(MYDIR, 'entrypoint')]
+    _c += [os.path.join(MYDIR, 'submit-jobs.sh')]
+    _c += [host + ':' + MYDIR]
+    subprocess.run(_c)
+  _c = ['podman', 'load', '-i']
+  _c += [os.path.join(MYDIR, 'pbs.tgz')]
+  _c += ['pbs:latest']
+  run_cmd(host, _c)
+
+def cleanup_containers(host):
+  print('Cleaning previous containers on %s' % host)
+  _c = ['podman', 'ps', '-aqf', 'label=pbs=1']
+  _s = []
+  if host != ME:
+    _s = ['ssh', host]
+  try:
+      p = subprocess.check_output(_s + _c)
+  except:
+    return
+  p = p.splitlines()
+  p = [x.strip() for x in p]
+  p = [x for x in p if len(x) > 0]
+  if len(p) > 0:
+    _c = ['podman', 'rm', '-vif'] + p + ['&>/dev/null']
+    run_cmd(host, _c)
+  _c = ['podman', 'run', '--network', 'host', '-it']
+  _c += ['--rm', '-l', 'pbs=1', '-v', '/tmp:/tmp/htmp']
+  _c += ['centos:8', 'rm', '-rf', '/tmp/htmp/pbs']
+  _c += ['&>/dev/null']
+  run_cmd(host, _c)
+
+def cleanup_system(host):
+  print('Cleaning system on %s' % host)
+  cleanup_containers(host)
+  _c = ['podman', 'rmi', '-f', 'pbs:latest']
+  run_cmd(host, _c)
+
+def setup_pbs(host, c, svrs, sips, moms, ncpus):
+  _e = os.path.join(MYDIR, 'entrypoint')
+  _c = ['podman', 'run', '--network', 'host', '-itd']
+  _c += ['--rm', '-l', 'pbs=1', '-v', '%s:%s' % (MYDIR, MYDIR)]
+  _c += ['-v', '/tmp/pbs:/var/spool/pbs']
+  _c += ['--entrypoint', _e, '--name', c[0]]
+  _c += ['--add-host=%s' % x for x in sips]
+  _c += ['pbs:latest']
+  _c += c[1:]
+  if c[2] == 'server':
+    if len(moms[c[0]]) > 0:
+      _c += [','.join(moms[c[0]])]
+      _c += [str(ncpus)]
+    else:
+      _c += ['none', '0']
+  elif c[2] == 'mom':
+    _c += [c[0]]
+  if len(svrs) > 1:
+    _c += [','.join(svrs)]
+  p = run_cmd(host, _c)
+  if p:
+    if c[2] == 'server':
+      _c = ['podman', 'exec', c[0]]
+      _c += [_e, 'waitsvr', ','.join(moms[c[0]])]
+      run_cmd(host, _c)
+    print('Configured %s' % c[0])
+  else:
+    print('Failed to configure %s' % c[0])
+  return p
+
+def setup_cluster(tconf, hosts, ips, conf):
+  _ts = tconf['total_num_svrs']
+  _mph = tconf['num_moms_per_host']
+  _cpm = tconf['num_cpus_per_mom']
+
+  _hl = len(hosts)
+  _confs = dict([(_h, {'ns': 0, 'svrs': [], 'moms': []}) for _h in hosts])
+  _hi = 0
+  for i in range(1, _ts + 1):
+    _confs[hosts[_hi]]['ns'] += 1
+    _hi += 1
+    if _hi == _hl:
+      _hi = 0
+  _tolms = _hl * _mph
+  _lps = 18000
+  _svrs = []
+  _sips = []
+  _scnt = 1
+  for i, _h in enumerate(hosts):
+    for _ in range(_confs[_h]['ns']):
+      _c = ['pbs-server-%d' % _scnt, 'default', 'server', str(_scnt)]
+      _c.append('1' if _scnt == 1 else '0')
+      _p = _lps
+      _lps += 2
+      _c.append(str(_p))
+      _c.append(str(_p + 1))
+      _svrs.append('pbs-server-%d:%d' % (_scnt, _p))
+      _sips.append('pbs-server-%d:%s' % (_scnt, ips[i]))
+      _confs[_h]['svrs'].append(_c)
+      _scnt += 1
+    for _ in range(_mph):
+      _c = ['', 'default', 'mom', str(_lps)]
+      _lps += 2
+      _confs[_h]['moms'].append(_c)
+  for _h in hosts:
+    _mc = len(_confs[_h]['moms'])
+    i = 0
+    while i != _mc:
+      for __h in hosts:
+        if i == _mc:
+          break
+        if _confs[__h]['ns'] == 0:
+          continue
+        for s in _confs[__h]['svrs']:
+          _confs[_h]['moms'][i].append(s[3])
+          _confs[_h]['moms'][i].append(s[5])
+          i += 1
+          if i == _mc:
+            break
+  svrs = dict([(_h, []) for _h in hosts])
+  moms = dict([(_h, []) for _h in hosts])
+  _mcs = dict([(str(i), 0) for i in range(1, _ts + 1)])
+  svrmoms = dict([('pbs-server-%d' % i, []) for i in range(1, _ts + 1)])
+  for _h in hosts:
+    svrs[_h].extend(_confs[_h]['svrs'])
+    for _c in _confs[_h]['moms']:
+      _s = _c[4]
+      _c[0] = 'pbs-mom-%s-%d' % (_s, _mcs[_s])
+      _c[4] = 'pbs-server-%s' % _s
+      svrmoms[_c[4]].append('%s:%s:%s' % (_c[0], _h, _c[3]))
+      moms[_h].append(_c)
+      _mcs[_s] += 1
+
+  with ProcessPoolExecutor(max_workers=len(hosts)) as executor:
+    _ps = []
+    for _h in hosts:
+      _ps.append(executor.submit(cleanup_containers, _h))
+    wait(_ps)
+
+  for _h in hosts:
+    run_cmd(_h, ['mkdir', '-p', '/tmp/pbs'])
+
+  r = [False]
+  with ProcessPoolExecutor(max_workers=10) as executor:
+    _ps = []
+    for _h, _cs in moms.items():
+      for _c in _cs:
+        _ps.append(executor.submit(setup_pbs, _h, _c, _svrs, _sips, svrmoms, _cpm))
+    for _h, _cs in svrs.items():
+      for _c in _cs:
+        _ps.append(executor.submit(setup_pbs, _h, _c, _svrs, _sips, svrmoms, _cpm))
+    r = list(set([_p.result() for _p in wait(_ps)[0]]))
+  if len(r) != 1:
+    return False
+  return r[0]
+
+def run_tests(conf, hosts, ips):
+  for _n, _s in conf['setups'].items():
+    print('Configuring setup: %s' % _n)
+    r = setup_cluster(_s, hosts, ips, conf)
+    if not r:
+      print('skipping test, see above for reason')
+    else:
+      subprocess.run([os.path.join(MYDIR, 'run-test.sh'), _n])
+
+def main():
+  if os.getuid() == 0:
+    print('This script must be run as non-root user!')
+    sys.exit(1)
+  if len(sys.argv) > 2:
+    print('Usage: python3 master.py [clean]')
+    sys.exit(1)
+
+  if len(sys.argv) == 2 and sys.argv[1] != 'clean':
+    print('Invalid option: %s' % sys.argv[1])
+    print('Usage: python3 master.py [clean]')
+    sys.exit(1)
+
+  os.chdir(MYDIR)
+
+  with open('config.json') as f:
+    conf = json.load(f)
+
+  if not os.path.isfile('nodes'):
+    print('Could not find nodes file')
+    sys.exit(1)
+
+  if not os.path.isfile('pbs.tgz'):
+    print('Could not find pbs.tgz')
+    sys.exit(1)
+
+  hosts = []
+  with open('nodes') as f:
+    hosts = f.read().splitlines()
+
+  if len(hosts) == 0:
+    print('No hosts defined in nodes file')
+    sys.exit(1)
+
+  hosts = [socket.getfqdn(_h) for _h in hosts]
+  ips = [socket.gethostbyname(_h) for _h in hosts]
+
+
+  with ProcessPoolExecutor(max_workers=len(hosts)) as executor:
+    _ps = []
+    for _h in hosts:
+      _ps.append(executor.submit(cleanup_system, _h))
+    wait(_ps)
+
+  if len(sys.argv) == 2:
+    sys.exit(0)
+
+  subprocess.run(['rm', '-rf', 'results'])
+
+  with ProcessPoolExecutor() as executor:
+    _ps = []
+    for _h in hosts:
+      _ps.append(executor.submit(copy_artifacts, _h))
+    wait(_ps)
+
+  run_tests(conf, hosts, ips)
+
+  with ProcessPoolExecutor(max_workers=len(hosts)) as executor:
+    _ps = []
+    for _h in hosts:
+      _ps.append(executor.submit(cleanup_system, _h))
+    wait(_ps)
+
+
+if __name__ == '__main__':
+  main()

--- a/test-scripts/readme.txt
+++ b/test-scripts/readme.txt
@@ -1,0 +1,21 @@
+How to use:
+
+1. Run build-image.sh <path to pbs src dir>
+   NOTE: for multiserver use https://github.com/subhasisb/openpbs/tree/msvr_rapid_proto
+
+2. copy generated <path to pbs src dir>/pbs.tgz to this dir (aka 'test-scripts' - dir in which this readme.txt exists)
+
+3. create file called 'nodes' in this dir and add per line uniq FQDN (IP not supported) of machine which are available for tests
+   NOTE1: Make sure you have password less to all nodes
+   NOTE2: FQDN should be resolvable
+   NOTE3: python3 should be install on first node in list
+   NOTE4: Make sure you have podman installed in all nodes
+   NOTE5: 'You' must be non-root user on all machines, root user is not supported
+
+4. copy this dir to first node and put it under your home directory
+
+5. run 'python3 master.py &> master.log' from this dir as yourself on first node
+
+6. once above finish, you should have 'results' dir in current dir, copy master.log in it, tar 'results'
+
+7. share results tarball with multiserver team

--- a/test-scripts/readme.txt
+++ b/test-scripts/readme.txt
@@ -1,18 +1,22 @@
 How to use:
 
 1. Run build-image.sh <path to pbs src dir>
-   NOTE: for multiserver use https://github.com/subhasisb/openpbs/tree/msvr_rapid_proto
+   NOTE1: for multiserver use https://github.com/subhasisb/openpbs/tree/msvr_rapid_proto
+   NOTE2: This step MUST be run on your machine
 
 2. copy generated <path to pbs src dir>/pbs.tgz to this dir (aka 'test-scripts' - dir in which this readme.txt exists)
+   NOTE: This step MUST be run on your machine
 
 3. create file called 'nodes' in this dir and add per line uniq FQDN (IP not supported) of machine which are available for tests
-   NOTE1: Make sure you have password less to all nodes
+   NOTE1: Make sure you have passwordless ssh between nodes
    NOTE2: FQDN should be resolvable
    NOTE3: python3 should be install on first node in list
    NOTE4: Make sure you have podman installed in all nodes
    NOTE5: 'You' must be non-root user on all machines, root user is not supported
+   NOTE6: This step MUST be run on your machine
 
 4. copy this dir to first node and put it under your home directory
+   NOTE: This step MUST be run on your machine
 
 5. run 'python3 master.py &> master.log' from this dir as yourself on first node
 

--- a/test-scripts/run-test.sh
+++ b/test-scripts/run-test.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+curdir=$(dirname $(readlink -f $0))
+cd ${curdir}
+
+resultdir=${curdir}/results/$1
+concmd="podman exec pbs-server-1 "
+
+###############################
+# utility funcs
+###############################
+function change_scheduling() {
+	${concmd} ${curdir}/entrypoint changesched $1
+}
+
+function wait_jobs() {
+	local _ct
+
+	while true
+	do
+		_ct=$(${concmd} /opt/pbs/bin/qstat -Bf 2>/dev/null | grep total_jobs | awk -F' = ' '{ print $2 }')
+		if [ "x${_ct}" == "x0" ]; then
+			echo "total_jobs: ${_ct}"
+			break
+		fi
+		echo "total_jobs: ${_ct}"
+		sleep 5
+	done
+}
+
+function collect_logs() {
+	local host svr svrs _d fsvr="" _destd=${resultdir}/$1
+
+	mkdir -p ${_destd}
+	for host in $(cat ${curdir}/nodes)
+	do
+		svrs=$(ssh ${host} ls -1 /tmp/pbs 2>/dev/null | grep pbs-server | sort -u)
+		if [ "x${svrs}" == "x" ]; then
+			continue
+		fi
+		for _d in ${svrs}
+		do
+			echo "Saving logs from ${_d}"
+			if [ -d /tmp/pbs/${_d} ]; then
+				cp -rf /tmp/pbs/${_d}/server_logs ${_destd}/${_d}-server-logs
+				truncate -s0 /tmp/pbs/${_d}/server_logs/*
+				cp -rf /tmp/pbs/${_d}/server_priv/accounting ${_destd}/${_d}-acc-logs
+				truncate -s0 /tmp/pbs/${_d}/server_priv/accounting/*
+				if [ "x${fsvr}" == "x" ]; then
+					cp -rf /tmp/pbs/${_d}/sched_logs ${_destd}/sched_logs
+					truncate -s0 /tmp/pbs/${_d}/sched_logs/*
+					fsvr=${_d}
+				fi
+			else
+				scp -qr ${host}:/tmp/pbs/${_d}/server_logs ${_destd}/${_d}-server-logs
+				ssh ${host} truncate -s0 /tmp/pbs/${_d}/server_logs/\*
+				scp -qr ${host}:/tmp/pbs/${_d}/server_priv/accounting ${_destd}/${_d}-acc-logs
+				ssh ${host} truncate -s0 /tmp/pbs/${_d}/server_priv/accounting/\*
+				if [ "x${fsvr}" == "x" ]; then
+					scp -qr ${host}:/tmp/pbs/${_d}/sched_logs ${_destd}/sched_logs
+					ssh ${host} truncate -s0 /tmp/pbs/${_d}/sched_logs/\*
+					fsvr=${_d}
+				fi
+			fi
+		done
+	done
+}
+
+function get_total_ncpus() {
+	echo $(${concmd} /opt/pbs/bin/pbsnodes -av | grep resources_available.ncpus | awk '{print $3}' | paste -sd+ | bc)
+}
+###############################
+# end of utility funcs
+###############################
+
+
+############################
+# test funcs
+############################
+function test_with_sched_off() {
+	local _ct
+
+	change_scheduling 0
+	_ct=$(get_total_ncpus)
+	${curdir}/submit-jobs.sh $(( _ct * 3 ))
+	change_scheduling 1
+	wait_jobs
+	collect_logs sched_off
+}
+
+function test_with_sched_on() {
+	local _ct
+
+	change_scheduling 1
+	_ct=$(get_total_ncpus)
+	${curdir}/submit-jobs.sh $(( _ct * 3 ))
+	wait_jobs
+	collect_logs sched_on
+}
+############################
+# end test funcs
+############################
+
+test_with_sched_off
+test_with_sched_on

--- a/test-scripts/submit-jobs.sh
+++ b/test-scripts/submit-jobs.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+_curdir=$(dirname $(readlink -f $0))
+_self=${_curdir}/$(basename $0)
+cd ${_curdir}
+
+if [ $# -gt 2 ]; then
+	echo "syntax: $0 <no. jobs-per-svr>"
+	exit 1
+fi
+
+if [ "x$1" == "xsubmit" ]; then
+	njobs=$2
+
+	. /etc/pbs.conf
+	export PBS_SERVER_INSTANCES=${PBS_SERVER}:${PBS_BATCH_SERVICE_PORT}
+
+	for i in $(seq 1 $njobs)
+	do
+		/opt/pbs/bin/qsub -koe -- /bin/date > /dev/null
+	done
+	exit 0
+fi
+
+if [ "x$1" == "xsvr-submit" ]; then
+	njobs=$2
+	users=$(awk -F: '/^(pbsu|tst)/ {print $1}' /etc/passwd)
+	_tu=$(awk -F: '/^(pbsu|tst)/ {print $1}' /etc/passwd | wc -l)
+	_jpu=$(( njobs / _tu ))
+
+	for usr in ${users}
+	do
+		( setsid sudo -Hiu ${usr} ${_self} submit ${_jpu} ) &
+	done
+	wait
+	exit 0
+fi
+
+if [ "x$1" == "xhost-submit" ]; then
+	njobs=$2
+	svrs=$(ls -1 /tmp/pbs 2>/dev/null | grep pbs-server | sort -u)
+	if [ "x${svrs}" == "x" ]; then
+		exit 0
+	fi
+
+	for svr in ${svrs}
+	do
+		( podman exec ${svr} ${_self} svr-submit ${njobs} ) &
+	done
+	wait
+	exit 0
+fi
+
+njobs=$1
+servers="$(podman exec pbs-server-1 grep PBS_SERVER_INSTANCES /etc/pbs.conf 2>/dev/null | cut -d= -f2)"
+if [ "x${servers}" == "x" ]; then
+	servers="pbs-server-1"
+fi
+_svrs=( ${servers//,/ } )
+_ts=${#_svrs[*]}
+_jps=$(( njobs / _ts ))
+
+echo "Total jobs: ${njobs}, Total svrs: ${_ts}, Jobs per Svr: ${_jps}"
+for host in $(cat nodes)
+do
+	( ssh ${host} ${_self} host-submit ${_jps} ) &
+done
+wait


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* Disable/remove code to authenticate using resvport to allow to run PBS in non-priv containers
* Ignore setting limits to allow to run mom in non-priv containers
* Add test scripts (just for safe keeping)

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[master.log](https://github.com/subhasisb/openpbs/files/5174818/master.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
