### PR TITLE
Code changes for Scheduler crash when a server/s has no nodes  + Move job issues

### DIFF
--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -297,8 +297,15 @@ parse_psi(char *conf_value)
 		}
 		if (pbs_conf.psi[i].name[0] == '\0')
 			strcpy(pbs_conf.psi[i].name, pbs_conf.pbs_server_name);
-		if (pbs_conf.psi[i].port == 0)
-			pbs_conf.psi[i].port = pbs_conf.batch_service_port;
+		if (pbs_conf.psi[i].port == 0) {
+			if (strcmp(pbs_conf.psi[i].name, pbs_conf.pbs_server_name) == 0)
+				pbs_conf.psi[i].port = pbs_conf.batch_service_port;
+			else {
+				fprintf(stderr, "Port number is mandatory for non local servers. Please correct PBS_SERVER_INSTANCES\n");
+				return -1;
+			}
+
+		}
 	}
 	free_string_array(list);
 	pbs_conf.pbs_num_servers = i;
@@ -928,7 +935,8 @@ __pbs_loadconf(int reload)
 		goto err;
 	}
 
-	parse_psi(psi_value ? psi_value : pbs_conf.pbs_server_name);
+	if (parse_psi(psi_value ? psi_value : pbs_conf.pbs_server_name) == -1)
+		goto err;
 	free(psi_value);
 
 	/*

--- a/src/lib/Libifl/pbs_loadconf.c
+++ b/src/lib/Libifl/pbs_loadconf.c
@@ -300,11 +300,8 @@ parse_psi(char *conf_value)
 		if (pbs_conf.psi[i].port == 0) {
 			if (strcmp(pbs_conf.psi[i].name, pbs_conf.pbs_server_name) == 0)
 				pbs_conf.psi[i].port = pbs_conf.batch_service_port;
-			else {
-				fprintf(stderr, "Port number is mandatory for non local servers. Please correct PBS_SERVER_INSTANCES\n");
-				return -1;
-			}
-
+			else
+				pbs_conf.psi[i].port = PBS_BATCH_SERVICE_PORT;
 		}
 	}
 	free_string_array(list);

--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1619,8 +1619,7 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 
 	get_resresv_spec(resresv, &spec, &pl);
 
-	if (using_svr_nodes && nodepart == NULL && (sinfo->svr_node_array[resresv->svr_index] != NULL) &&
-		sinfo->svr_node_array[resresv->svr_index]->unassoc_nodes != NULL) {
+	if (using_svr_nodes && nodepart == NULL && sinfo->svr_node_array[resresv->svr_index] != NULL && sinfo->svr_node_array[resresv->svr_index]->unassoc_nodes != NULL) {
 		ninfo_arr = sinfo->svr_node_array[resresv->svr_index]->unassoc_nodes;
 		svr_index_used = resresv->svr_index;
 	}

--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1619,7 +1619,8 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 
 	get_resresv_spec(resresv, &spec, &pl);
 
-	if (using_svr_nodes && nodepart == NULL && sinfo->svr_node_array[resresv->svr_index]->unassoc_nodes != NULL) {
+	if (using_svr_nodes && nodepart == NULL && (sinfo->svr_node_array[resresv->svr_index] != NULL) &&
+		sinfo->svr_node_array[resresv->svr_index]->unassoc_nodes != NULL) {
 		ninfo_arr = sinfo->svr_node_array[resresv->svr_index]->unassoc_nodes;
 		svr_index_used = resresv->svr_index;
 	}

--- a/src/server/multi_svr.c
+++ b/src/server/multi_svr.c
@@ -138,7 +138,7 @@ init_msi()
 
 	for (i = 0; i < get_num_servers(); i++) {
 
-		if (!strcmp(pbs_conf.psi[i].name, server_host) &&
+		if (!strcmp(pbs_conf.psi[i].name, pbs_conf.pbs_server_name) &&
 		    (pbs_conf.psi[i].port == pbs_server_port_dis))
 			continue;
 


### PR DESCRIPTION

<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
Scheduler crashes when a single or a set of servers do not have any nodes. Following is the backtrace.
```
(gdb) bt
#0  on_segv (sig=0) at pbs_sched.c:172
#1  <signal handler called>
#2  0x0000000000471bee in check_normal_node_path (policy=0xd4f4b0, sinfo=0xd185c0, 
    qinfo=0xcc2460, resresv=0x7f49f8001910, flags=0, err=0xd4e8e0) at check.c:1622
#3  0x000000000047183a in check_nodes (policy=0xd4f4b0, sinfo=0xd185c0, qinfo=0xcc2460, 
    resresv=0x7f49f8001910, flags=0, err=0xd4e8e0) at check.c:1486
#4  0x0000000000470d66 in is_ok_to_run (policy=0xd4f4b0, sinfo=0xd185c0, 
    qinfo=0xcc2460, resresv=0x7f49f8001910, flags=0, perr=0xd4e8e0) at check.c:1074
#5  0x00000000004202dd in main_sched_loop (policy=0xd4f4b0, sd=10, sinfo=0xd185c0, 
    rerr=0x7fff07ee8898) at fifo.c:897
#6  0x000000000041ff49 in scheduling_cycle (sd=10, jobid=0x0) at fifo.c:744
#7  0x000000000041fb80 in intermediate_schedule (sd=10, jobid=0x0) at fifo.c:610
#8  0x000000000041fad6 in schedule (cmd=1, sd=10, runjobid=0x0) at fifo.c:565
#9  0x000000000041e928 in schedule_wrapper (read_fdset=0x7fff07ee9230, opt_no_restart=0)
    at pbs_sched.c:1598
#10 0x000000000041e233 in main (argc=1, argv=0x7fff07ee9678) at pbs_sched.c:1397
```

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
Following are the steps that Scheduler follows when selecting a set of nodes for jobs.
1. Prefers local nodes if a Server has nodes.
2. If a Server does not have any nodes then it first tries to check if there are any un associated nodes in svr_node_array corresponding to this server. 
3. If it does not have any un associated nodes also then it tries with other server's nodes. 

Before Scheduler goes to step 3. it is crashing because of lack of a NULL check for sinfo->svr_node_array[resresv->svr_index]

Above NULL check helps in Scheduler going to step 3. 
This helps to avoid the crash but it has given couple of other issues as mentioned below.

When jobs are moved from the server which do not have any nodes then jobs are not successfully moved to the destination servers. Following is snippet which shows this.

**snippet from logs**
09/06/2020 11:55:20;0008;Server@spark;Job;12.spark-2;send of job to workq@spark:15001 failed error = 15010
    09/06/2020 11:55:20;0040;Server@spark;Svr;spark-2;Scheduler sent command 1
    09/06/2020 11:55:20;0100;Server@spark;Req;;Type 23 request received from Scheduler@spark, sock=15
    09/06/2020 11:55:20;0001;Server@spark;Req;;Could not connect to Mom, svr_connect returned -2
    **09/06/2020 11:55:20;0008;Server@spark;Job;13.spark-2;send of job to workq@spark:15001 failed error = 15010**
    09/06/2020 11:55:20;0100;Server@spark;Req;;Type 23 request received from Scheduler@spark, sock=15
    09/06/2020 11:55:20;0001;Server@spark;Req;;Could not connect to Mom, svr_connect returned -2
    **09/06/2020 11:55:20;0008;Server@spark;Job;14.spark-2;send of job to workq@spark:15001 failed error = 15010**
    09/06/2020 11:55:20;0100;Server@spark;Req;;Type 21 request received from Scheduler@spark, sock=15

**Analysis and Root cause**
When the server having no nodes is asked to run jobs upon the request from Scheduler, this server is not able to connect to pbs_comm. Since it is not able to connect to pbs_comm it fails to move the jobs to the destination server. Root cause is server having no nodes does not contain a tpp stream to the other or destination server.

This is especially happening when port number for remote servers/non local servers is not specified in PBS_SERVER_INSTANCES . For example if pbs.conf looks like
[root@spark pbspro_rjob_test]# cat /etc/pbs_2.conf 
PBS_CORE_LIMIT=unlimited
PBS_SCP=/usr/bin/scp
PBS_SERVER=spark-2
PBS_EXEC=/opt/pbs
PBS_HOME=/var/spool/pbs_2
PBS_START_SCHED=0
PBS_START_COMM=0
PBS_START_SERVER=1
PBS_START_MOM=1
PBS_MOM_SERVICE_PORT=28002
PBS_MANAGER_SERVICE_PORT=28003
PBS_BATCH_SERVICE_PORT=18002
PBS_BATCH_SERVICE_PORT_DIS=18002
PBS_DATA_SERVICE_PORT=18003
PBS_SERVER_INSTANCES=spark,spark-2:18002

As part of initialising tpp streams to the remote servers when port number is not given, for example in the above configuration spark is remote server but port number is not given, it is assuming that the port number is 18002 itself for spark and adding the stream for this entry. Ideally port number for spark is 15001 and hence there is no tpp stream for this server. So when it is time to move a job this server does not find a stream to remote server and hence the move fails.

**Solution**
- Admins make sure they provide port numbers for all remote servers as a mandatory.
- If not we can warn them with the following message so that they get an opportunity to correct configuration.
`Error initializing the PBS dataservice
Error details:
Creating the PBS Data Service...
Starting PBS Data Service..
Port number is mandatory for non local servers. Please correct PBS_SERVER_INSTANCES
pbs_ds_password: Could not load pbs configuration

Error setting password for PBS Data Service
[root@spark pbspro_rjob_test]# ps -ef |grep pbs_ser
root     118768      0  0 06:24 ?        00:00:00 /opt/pbs/sbin/pbs_server.bin
root     119587  71739  0 06:24 pts/3    00:00:00 grep --color=auto pbs_ser`

**Right configuration for the above scenario is:**
[root@spark pbspro_rjob_test]# cat /etc/pbs_2.conf 
PBS_CORE_LIMIT=unlimited
PBS_SCP=/usr/bin/scp
PBS_SERVER=spark-2
PBS_EXEC=/opt/pbs
PBS_HOME=/var/spool/pbs_2
PBS_START_SCHED=0
PBS_START_COMM=0
PBS_START_SERVER=1
PBS_START_MOM=1
PBS_MOM_SERVICE_PORT=28002
PBS_MANAGER_SERVICE_PORT=28003
PBS_BATCH_SERVICE_PORT=18002
PBS_BATCH_SERVICE_PORT_DIS=18002
PBS_DATA_SERVICE_PORT=18003
PBS_SERVER_INSTANCES=spark:15001,spark-2:18002
#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->

Attached are the detail logs.
[PR_138_logs.docx](https://github.com/subhasisb/openpbs/files/5182678/PR_138_logs.docx)


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
