### PR TITLE
Sched will do sync job run for non-local jobs

### DIFF
--- a/src/scheduler/check.c
+++ b/src/scheduler/check.c
@@ -1622,6 +1622,7 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 	if (using_svr_nodes && nodepart == NULL && sinfo->svr_node_array[resresv->svr_index] != NULL && sinfo->svr_node_array[resresv->svr_index]->unassoc_nodes != NULL) {
 		ninfo_arr = sinfo->svr_node_array[resresv->svr_index]->unassoc_nodes;
 		svr_index_used = resresv->svr_index;
+		resresv->msvr_local = 1;
 	}
 
 	err->status_code = NOT_RUN;
@@ -1633,8 +1634,10 @@ check_normal_node_path(status *policy, server_info *sinfo, queue_info *qinfo, re
 	else if (svr_index_used != -1) { /* Try "all" nodes, the owner doesn't have enough resources to run the job */
 		ninfo_arr = sinfo->unassoc_nodes;
 		rc = eval_selspec(policy, spec, pl, ninfo_arr, nodepart, resresv, flags, &nspec_arr, err);
-		if (rc > 0)
+		if (rc > 0) {
+			resresv->msvr_local = 0;
 			return nspec_arr;
+		}
 	}
 
 	/* We were not told why the resresv can't run: Use generic reason */

--- a/src/scheduler/data_types.h
+++ b/src/scheduler/data_types.h
@@ -800,6 +800,7 @@ struct resource_resv
 	unsigned is_resv : 1;		/* res resv is an advanced reservation */
 
 	unsigned will_use_multinode:1;	/* res resv will use multiple nodes */
+	unsigned msvr_local:1;	/* res resv ran on the local/owner server's resources? */
 
 	char *name;			/* name of res resv */
 	char *user;			/* username of the owner of the res resv */

--- a/src/scheduler/resource_resv.c
+++ b/src/scheduler/resource_resv.c
@@ -159,6 +159,7 @@ new_resource_resv()
 	resresv->is_job = 0;
 	resresv->is_shrink_to_fit = 0;
 	resresv->is_resv = 0;
+	resresv->msvr_local = 1;
 
 	resresv->will_use_multinode = 0;
 


### PR DESCRIPTION
This is to implement the sched side changes needed to handle the race conditions around non-local and multi-node split jobs. With this, such jobs will be run with PBS_BATCH_AsyrunJob_ack (97) batch request, instead of PBS_BATCH_AsyrunJob (23).

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
I tested single node jobs which need to be run on a different server, the sched successfully submtited type 97 request instead of type 23 for such jobs. But I couldn't test multi-node jobs which need to be split since, I think, we don't support that yet.


<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
