### PR TITLE
Fix for permission error on qmgr broadcast to all servers

### DIFF
--- a/src/scheduler/node_info.c
+++ b/src/scheduler/node_info.c
@@ -149,6 +149,7 @@
 #include "sort.h"
 #include "node_partition.h"
 #include "resource.h"
+#include "pbs_error.h"
 #include "pbs_internal.h"
 #include "server_info.h"
 #include "pbs_share.h"
@@ -449,7 +450,7 @@ query_nodes(int pbs_sd, server_info *sinfo)
 	}
 
 	/* get nodes from all PBS servers */
-	if (((nodes = pbs_statvnode(pbs_sd, NULL, attrib, NULL)) == NULL) || pbs_errno) {
+	if (((nodes = pbs_statvnode(pbs_sd, NULL, attrib, NULL)) == NULL) || (pbs_errno && pbs_errno != PBSE_NONODES)) {
 		err = pbs_geterrmsg(pbs_sd);
 		log_eventf(PBSEVENT_SCHED, PBS_EVENTCLASS_NODE, LOG_INFO, "", "Error getting nodes: %s", err);
 		return NULL;
@@ -4871,7 +4872,7 @@ create_execvnode(nspec **ns)
  *
  * @param[in]	execvnode	-	the execvnode to parse
  * @param[in]	sinfo		-	server to get the nodes from
- * @param[in]	sel		- select to map 
+ * @param[in]	sel		- select to map
  *
  * @return	a newly allocated nspec array for the execvnode
  *

--- a/src/server/svr_chk_owner.c
+++ b/src/server/svr_chk_owner.c
@@ -247,6 +247,15 @@ svr_get_privilege(char *user, char *host)
 			}
 		}
 		if (is_root == 0) {
+			int i;
+			for (i = 0; i < get_num_servers(); i++) {
+				if (is_same_host(host, pbs_conf.psi[i].name)) {
+					is_root = 1;
+					break;
+				}
+			}
+		}
+		if (is_root == 0) {
 			/* Now try with DNS lookup. */
 			if (is_same_host(host, server_host)) {
 				is_root = 1;

--- a/test-scripts/entrypoint
+++ b/test-scripts/entrypoint
@@ -1,18 +1,5 @@
 #!/bin/bash
 
-if [ "x$1" == "xchangesched" ]; then
-    servers="$(grep PBS_SERVER_INSTANCES /etc/pbs.conf 2>/dev/null | cut -d= -f2)"
-    if [ "x${servers}" == "x" ]; then
-        /opt/pbs/bin/qmgr -c "s s scheduling=$2"
-        exit 0
-    fi
-    for svr in ${servers//,/ }
-    do
-        PBS_SERVER_INSTANCES=${svr} /opt/pbs/bin/qmgr -c "s s scheduling=$2" &>/dev/null
-    done
-    exit 0
-fi
-
 if [ "x$1" == "xwaitsvr" ]; then
     . /etc/pbs.conf
     export PBS_SERVER_INSTANCES=${PBS_SERVER}:${PBS_BATCH_SERVICE_PORT}

--- a/test-scripts/master.py
+++ b/test-scripts/master.py
@@ -211,6 +211,7 @@ def main():
   hosts = []
   with open('nodes') as f:
     hosts = f.read().splitlines()
+    hosts = [_h for _h in hosts if len(_h.strip()) > 0]
 
   if len(hosts) == 0:
     print('No hosts defined in nodes file')

--- a/test-scripts/run-test.sh
+++ b/test-scripts/run-test.sh
@@ -9,10 +9,6 @@ concmd="podman exec pbs-server-1 "
 ###############################
 # utility funcs
 ###############################
-function change_scheduling() {
-	${concmd} ${curdir}/entrypoint changesched $1
-}
-
 function wait_jobs() {
 	local _ct
 
@@ -80,10 +76,10 @@ function get_total_ncpus() {
 function test_with_sched_off() {
 	local _ct
 
-	change_scheduling 0
+	${concmd} /opt/pbs/bin/qmgr -c "s s scheduling=0"
 	_ct=$(get_total_ncpus)
 	${curdir}/submit-jobs.sh $(( _ct * 3 ))
-	change_scheduling 1
+	${concmd} /opt/pbs/bin/qmgr -c "s s scheduling=1"
 	wait_jobs
 	collect_logs sched_off
 }
@@ -91,7 +87,7 @@ function test_with_sched_off() {
 function test_with_sched_on() {
 	local _ct
 
-	change_scheduling 1
+	${concmd} /opt/pbs/bin/qmgr -c "s s scheduling=1"
 	_ct=$(get_total_ncpus)
 	${curdir}/submit-jobs.sh $(( _ct * 3 ))
 	wait_jobs


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
* qmgr fails with 15007 (PBSE_PERM) error when server is on another host, because server by default consider root on localhost/server_host as privileged, but in case of multiple servers, all servers should consider all servers host's root user as priv user 
* sched doesn't schedule any jobs if one of the servers doesn't have any nodes due to pbs_statvnodes fails with PBSE_NONODES

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->
* Fixed permission error by validating host against all server's host if req user is root
* Ignore PBSE_NONODES in query_nodes() in sched
* Modified test-scripts to make use of qmgr broadcast instead going to each server and changing scheduling value

#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->
* None

#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from run
[test.txt](https://github.com/subhasisb/openpbs/files/5207750/test.txt)
ning the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->
[master.log](https://github.com/subhasisb/openpbs/files/5207748/master.log)



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
