### PR TITLE
multi-node using broadcasting resc update

### DIFF
--- a/src/include/batch_request.h
+++ b/src/include/batch_request.h
@@ -211,6 +211,13 @@ struct rq_defschrpy {
 	char *rq_txt;
 };
 
+/* Resource update from peer server */
+struct rq_rescupdate {
+	char rq_jid[PBS_MAXSVRJOBID + 1];
+	int op;
+	char *selectspec;
+};
+
 /* Copy/Delete Files (Server -> MOM Only) */
 
 #define STDJOBFILE 1
@@ -314,6 +321,7 @@ struct batch_request {
 		struct rq_hookfile rq_hookfile;
 		struct rq_preempt rq_preempt;
 		struct rq_cred rq_cred;
+		struct rq_rescupdate rq_rescupdate;
 	} rq_ind;
 };
 
@@ -335,6 +343,7 @@ extern int isode_request_read(int, struct batch_request *);
 extern void req_stat_job(struct batch_request *);
 extern void req_stat_resv(struct batch_request *);
 extern void req_stat_resc(struct batch_request *);
+extern void req_resc_update(struct batch_request *);
 extern void req_rerunjob(struct batch_request *);
 extern void arrayfree(char **);
 
@@ -413,6 +422,7 @@ extern int encode_DIS_Cred(int, char *, char *, int, char *, size_t, long);
 extern int dis_request_read(int, struct batch_request *);
 extern int dis_reply_read(int, struct batch_reply *, int);
 extern int decode_DIS_PreemptJobs(int, struct batch_request *);
+extern int decode_DIS_RescUpdate(int, struct batch_request *);
 
 #ifdef __cplusplus
 }

--- a/src/include/libpbs.h
+++ b/src/include/libpbs.h
@@ -289,6 +289,7 @@ struct batch_reply
 #define PBS_BATCH_Authenticate		95
 #define PBS_BATCH_ModifyJob_Async	96
 #define PBS_BATCH_AsyrunJob_ack	97
+#define PBS_BATCH_Resc_Update	98
 
 #define PBS_BATCH_FileOpt_Default	0
 #define PBS_BATCH_FileOpt_OFlg		1

--- a/src/include/libutil.h
+++ b/src/include/libutil.h
@@ -347,6 +347,8 @@ void encode_SHA(char*, size_t, char **);
  */
 extern int get_num_servers();
 
+extern int msvr_mode(void);
+
 extern int parse_pbs_name_port(char *, char *, int *);
 
 extern int rand_num();

--- a/src/include/pbs_nodes.h
+++ b/src/include/pbs_nodes.h
@@ -194,7 +194,7 @@ struct	prop {
 };
 
 struct	jobinfo {
-	struct	job	*job;
+	char	*job;
 	int		has_cpu;
 	size_t		mem;
 	struct	jobinfo	*next;
@@ -427,7 +427,7 @@ extern	int	chk_vnode_pool(attribute *, void *, int);
 extern	void	free_pnode(struct pbsnode *);
 extern	int	save_nodes_db(int, void *);
 extern void	propagate_socket_licensing(mominfo_t *);
-
+extern void	update_jobs_on_node(char *, char *, int);
 extern char *msg_daemonname;
 
 #define	NODE_TOPOLOGY_TYPE_HWLOC	"hwloc:"
@@ -465,6 +465,7 @@ extern void		destroy_vmap(void *);
 extern mominfo_t	*find_vmapent_byID(void *, const char *);
 extern int		add_vmapent_byID(void *, const char *, void *);
 extern  int		open_momstream(mominfo_t *);
+extern void		add_mom_mcast(mominfo_t *, int *);
 
 #ifdef	__cplusplus
 }

--- a/src/include/server.h
+++ b/src/include/server.h
@@ -188,7 +188,6 @@ extern void			memory_debug_log(struct work_task *ptask);
 
 /* multi-server functions */
 extern void *	get_peersvr(struct sockaddr_in*);
-extern int	msvr_mode(void);
 extern void *	create_svr_entry(char *, unsigned int);
 extern int	init_msi();
 

--- a/src/lib/Libattr/attr_node_func.c
+++ b/src/lib/Libattr/attr_node_func.c
@@ -527,7 +527,7 @@ encode_jobs(const attribute *pattr, pbs_list_head *ph, char *aname, char *rname,
 			jobcnt++;
 			/* add 3 to length of node name for slash, comma, and space */
 			/* plus one for the cpu index				   */
-			strsize += strlen(jip->job->ji_qs.ji_jobid) + 4;
+			strsize += strlen(jip->job) + 4;
 			i = psubn->index;
 			/* now add additional space needed for the cpu index */
 			while ((i = i/10) != 0)
@@ -554,8 +554,8 @@ encode_jobs(const attribute *pattr, pbs_list_head *ph, char *aname, char *rname,
 				i++;
 
 			sprintf(job_str + offset, "%s/%ld",
-				jip->job->ji_qs.ji_jobid, psubn->index);
-			offset += strlen(jip->job->ji_qs.ji_jobid) + 1;
+				jip->job, psubn->index);
+			offset += strlen(jip->job) + 1;
 			j = psubn->index;
 			while ((j = j/10) != 0)
 				offset++;

--- a/src/lib/Libutil/misc_utils.c
+++ b/src/lib/Libutil/misc_utils.c
@@ -2257,3 +2257,15 @@ rand_num()
 
 	return rand();
 }
+
+/**
+ * @brief
+ * 	Return multiserver mode
+ *
+ * @return int
+ */
+int
+msvr_mode(void)
+{
+	return (get_num_servers() > 1);
+}

--- a/src/resmom/mom_comm.c
+++ b/src/resmom/mom_comm.c
@@ -3016,14 +3016,21 @@ im_request(int stream, int version)
 		tpp_close(stream);
 		return;
 	}
-	ipaddr = ntohl(addr->sin_addr.s_addr);
-	DBPRT(("connect from %s\n", netaddr(addr)))
-	if (!addrfind(ipaddr)) {
-		sprintf(log_buffer, "bad connect from %s",
-			netaddr(addr));
-		log_err(-1, __func__, log_buffer);
-		im_eof(stream, 0);
-		return;
+
+	/* This change is temporary in multi-svr branch.
+	This will disable authentication between sister moms 
+	This is to make testing easy
+	*/
+	if (!msvr_mode()) {
+		ipaddr = ntohl(addr->sin_addr.s_addr);
+		DBPRT(("connect from %s\n", netaddr(addr)))
+		if (!addrfind(ipaddr)) {
+			sprintf(log_buffer, "bad connect from %s",
+				netaddr(addr));
+			log_err(-1, __func__, log_buffer);
+			im_eof(stream, 0);
+			return;
+		}
 	}
 
 	jobid = disrst(stream, &ret);

--- a/src/resmom/start_exec.c
+++ b/src/resmom/start_exec.c
@@ -5645,7 +5645,6 @@ job_nodes_inner(struct job *pjob, hnodent **mynp)
 			 * Mom in case of multiple-Moms for the allocated vnodes
 			 */
 			n = 0;
-
 			if (enable_exechost2 == 0) {
 				while ((*peh != '/') && (*peh != '\0') &&
 					(n < PBS_MAXNODENAME)) {

--- a/src/server/dis_read.c
+++ b/src/server/dis_read.c
@@ -643,7 +643,11 @@ dis_request_read(int sfds, struct batch_request *request)
 			break;
 
 		case PBS_BATCH_PreemptJobs:
-			decode_DIS_PreemptJobs(sfds, request);
+			decode_DIS_PreemptJobs(sfds, request); 
+			break;
+
+		case PBS_BATCH_Resc_Update:
+			decode_DIS_RescUpdate(sfds, request);
 			break;
 
 #else	/* yes PBS_MOM */

--- a/src/server/mom_info.c
+++ b/src/server/mom_info.c
@@ -408,13 +408,16 @@ mominfo_t*
 create_svrmom_struct(char *phost, int port)
 {
 	u_long		*pul = NULL;
+	mominfo_t *pmom;
 
 	if (make_host_addresses_list(phost, &pul)) {
 		free(pul);
 		return NULL;
 	}
 
-	return create_svrmom_entry(phost, port, pul, 1);
+	pmom = create_svrmom_entry(phost, port, pul, 1);
+
+	return pmom;
 }
 
 /**

--- a/src/server/node_func.c
+++ b/src/server/node_func.c
@@ -404,6 +404,7 @@ subnode_delete(struct pbssubn *psubn)
 
 	for (jip = psubn->jobs; jip; jip = jipt) {
 		jipt = jip->next;
+		free(jip->job);
 		free(jip);
 	}
 	psubn->jobs  = NULL;

--- a/src/server/process_request.c
+++ b/src/server/process_request.c
@@ -975,6 +975,9 @@ dispatch_request(int sfds, struct batch_request *request)
 		case PBS_BATCH_StatusRsc:
 			req_stat_resc(request);
 			break;
+		case PBS_BATCH_Resc_Update:
+			req_resc_update(request);
+			break;
 #else	/* MOM only functions */
 
 		case PBS_BATCH_CopyFiles:
@@ -1555,6 +1558,9 @@ free_br(struct batch_request *preq)
 			break;
 		case PBS_BATCH_MoveJob:
 			free(preq->rq_ind.rq_move.run_exec_vnode);
+			break;
+		case PBS_BATCH_Resc_Update:
+			free(preq->rq_ind.rq_rescupdate.selectspec);
 			break;
 #endif /* PBS_MOM */
 	}

--- a/src/server/svr_func.c
+++ b/src/server/svr_func.c
@@ -407,10 +407,10 @@ set_resc_assigned(void *pobj, int objtype, enum batch_op op)
 	else if ((objtype == 0) && (pjob->ji_myResv == NULL)) {
 		if (pjob->ji_wattr[(int) JOB_ATR_resc_released].at_flags & ATR_VFLAG_SET)
 			/* This is just the normal case when job was not suspended but trying to run| end */
-			update_node_rassn(&pjob->ji_wattr[(int) JOB_ATR_resc_released], op);
+			update_job_node_rassn(pjob, &pjob->ji_wattr[(int) JOB_ATR_resc_released], op);
 		else
 			/* updating all resources from exec vnode attribute */
-			update_node_rassn(&pjob->ji_wattr[(int) JOB_ATR_exec_vnode], op);
+			update_job_node_rassn(pjob, &pjob->ji_wattr[(int) JOB_ATR_exec_vnode], op);
 		if (pjob->ji_wattr[(int)JOB_ATR_exec_vnode_deallocated].at_flags & ATR_VFLAG_SET) {
 			update_job_node_rassn(pjob, &pjob->ji_wattr[(int) JOB_ATR_exec_vnode_deallocated], op);
 		}


### PR DESCRIPTION
Approach #2 on multi-nodes:
Node structures are created selectively on servers. When a server receives a exec_vnode to process and it could not find  that node associated with its cluster, this request is broadcasted. The receiving servers will act on the request and update the resources assigned, jobs and node state accordingly.

Note: Inter-mom communication authentication using clusteraddr2 is disabled to make testing easier. This has to be used in a trusted cluster.