### PR TITLE
Bug fix for avoiding scheduler querying server universe in a corner case

### DIFF
--- a/src/scheduler/pbs_sched.c
+++ b/src/scheduler/pbs_sched.c
@@ -1377,8 +1377,11 @@ main(int argc, char *argv[])
 			 * we should go to the next block of code.
 			 */
 			accept_svr_conn(&max_sd, &num_connected_svrs);
-			if (num_connected_svrs != get_num_servers())
-				continue;
+		}
+
+		if (num_connected_svrs != get_num_servers()) {
+			sleep(1); /* To give some timefor other server to come up */
+			continue;
 		}
 
 		if (schedule_wrapper(&read_fdset, opt_no_restart, &num_connected_svrs) == 1)


### PR DESCRIPTION
<!--- Please review your changes in preview mode -->
<!--- Provide a general summary of your changes in the Title above -->

#### Describe Bug or Feature
<!--- Describe the problem, ideally from the customer's viewpoint  -->
When a server goes down scheduler detects it and stops scheduling. But at times it queries server universe unnecessarily and comes to know the fact that one of the server is down. If we can detect the server going down early which allows us to not to query server when there is no need. Of course this is not possible all the times. But whenever we detect it early we stop querying server universe. This avoids burden on server/s.

This also helps in avoiding 15034 errors when servers are coming up one after the other.

**sched_logs snippet**
09/24/2020 05:40:46;0080;pbs_sched;Req;;Updating scheduler attributes
09/24/2020 05:40:46;0080;pbs_sched;Req;;Starting Scheduling Cycle
09/24/2020 05:40:46;0040;pbs_sched;Resv;resv_info;pbs_statresv failed:  (15034)
09/24/2020 05:40:46;0040;pbs_sched;Node;;Error getting nodes: (null)
09/24/2020 05:40:46;0002;pbs_sched;Svr;;Problem with creating server data structure

**After fix:**
[root@spark pbspro_rjob_test]# ../bin/msvr_setup 2 start
Starting PBS
PBS comm
/opt/pbs/sbin/pbs_comm ready (pid=67002), Proxy Name:spark:17001, Threads:4
PBS mom
PBS sched
Connecting to PBS dataservice....connected to PBS dataservice@spark
Licenses valid for 10000000 Floating hosts
PBS server
Starting PBS
PBS mom
Connecting to PBS dataservice....connected to PBS dataservice@spark-2
Licenses valid for 10000000 Floating hosts
PBS server
[root@spark pbspro_rjob_test]# for i in $(seq 1 8); do  qsub -koed -- /bin/sleep  ; done
8.spark-2
9.spark-2
10.spark-2
11.spark-2
16.spark
12.spark-2
13.spark-2
17.spark
[root@spark pbspro_rjob_test]# qstat -s

sched_logs snippet:
09/24/2020 07:13:15;0080;pbs_sched;Req;;Starting Scheduling Cycle
09/24/2020 07:13:15;0080;pbs_sched;Job;8.spark-2;Considering job to run
09/24/2020 07:13:15;0040;pbs_sched;Job;8.spark-2;Job run
09/24/2020 07:13:15;0080;pbs_sched;Req;;Leaving Scheduling Cycle
09/24/2020 07:13:15;0080;pbs_sched;Req;;Starting Scheduling Cycle
09/24/2020 07:13:15;0080;pbs_sched;Job;9.spark-2;Considering job to run
09/24/2020 07:13:15;0040;pbs_sched;Job;9.spark-2;Job run
09/24/2020 07:13:15;0080;pbs_sched;Req;;Leaving Scheduling Cycle
09/24/2020 07:13:15;0080;pbs_sched;Req;;Starting Scheduling Cycle
09/24/2020 07:13:15;0080;pbs_sched;Job;10.spark-2;Considering job to run
09/24/2020 07:13:15;0040;pbs_sched;Job;10.spark-2;Job run
09/24/2020 07:13:15;0080;pbs_sched;Req;;Leaving Scheduling Cycle
09/24/2020 07:13:15;0080;pbs_sched;Req;;Starting Scheduling Cycle
09/24/2020 07:13:15;0080;pbs_sched;Job;11.spark-2;Considering job to run
09/24/2020 07:13:15;0040;pbs_sched;Job;11.spark-2;Job run
09/24/2020 07:13:15;0080;pbs_sched;Req;;Leaving Scheduling Cycle
09/24/2020 07:13:15;0080;pbs_sched;Req;;Starting Scheduling Cycle
09/24/2020 07:13:15;0080;pbs_sched;Job;16.spark;Considering job to run
09/24/2020 07:13:15;0040;pbs_sched;Job;16.spark;Job run
09/24/2020 07:13:15;0080;pbs_sched;Job;12.spark-2;Considering job to run
09/24/2020 07:13:15;0040;pbs_sched;Job;12.spark-2;Job run
09/24/2020 07:13:15;0080;pbs_sched;Req;;Leaving Scheduling Cycle
09/24/2020 07:13:15;0080;pbs_sched;Req;;Starting Scheduling Cycle
09/24/2020 07:13:15;0080;pbs_sched;Job;13.spark-2;Considering job to run
09/24/2020 07:13:15;0040;pbs_sched;Job;13.spark-2;Job run
09/24/2020 07:13:15;0080;pbs_sched;Job;17.spark;Considering job to run
09/24/2020 07:13:15;0040;pbs_sched;Job;17.spark;Job run
09/24/2020 07:13:15;0080;pbs_sched;Req;;Leaving Scheduling Cycle

#### Describe Your Change
<!--- Say how you fixed the problem.  Please describe your code changes in detail for reviewer -->


#### Link to Design Doc
<!--- If there is a design, link to it here: **[project documentation area](https://pbspro.atlassian.net/wiki/display/PD)** -->


#### Attach Test and Valgrind Logs/Output
<!--- Please attach your test log output from running the test you added (or from existing tests that cover your changes) -->
<!--- Don't forget to run Valgrind if appropriate and attach the resulting logs -->



<!--- Pull Request Guidelines: [Pull Request Guidelines](https://pbspro.atlassian.net/wiki/spaces/DG/pages/1187348483/Pull+Request+Guidelines) -->
